### PR TITLE
#2: Add count to Eventually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - id: flake8
     language_version: python3.10
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
+  rev: v0.942
   hooks:
   - id: mypy
     language_version: python3.10

--- a/screenpy/actions/eventually.py
+++ b/screenpy/actions/eventually.py
@@ -101,6 +101,7 @@ class Eventually:
 
         end_time = time.time() + self.timeout
 
+        count = 0
         with the_narrator.mic_cable_kinked():
             while True:
                 the_narrator.clear_backup()
@@ -111,6 +112,7 @@ class Eventually:
                     self.caught_error = exc
                     self.unique_errors.add((exc.__class__.__name__, str(exc)))
 
+                count += 1
                 time.sleep(self.poll)
                 if time.time() > end_time:
                     break
@@ -119,8 +121,8 @@ class Eventually:
             f"{e[0]}: {e[1]}" for e in self.unique_errors
         )
         msg = (
-            f"{the_actor} used Eventually for {self.timeout} seconds,"
-            f" but got:\n    {unique_errors_message}"
+            f"{the_actor} tried to Eventually {self.performable_to_log} {count} times"
+            f" over {self.timeout} seconds, but got:\n    {unique_errors_message}"
         )
         raise DeliveryError(msg) from self.caught_error
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -62,7 +62,6 @@ class TestDebug:
 
 
 class TestEventually:
-
     def get_mock_action(self, **kwargs):
         mock_action = mock.Mock()
         mock_action.perform_as = mock.Mock(**kwargs)
@@ -143,6 +142,19 @@ class TestEventually:
             Eventually(MockAction).perform_as(Tester)
 
         assert mocked_time.time.call_count == num_calls + 1
+
+    @mock.patch("screenpy.actions.eventually.time")
+    def test_timeout_mentions_num_executions(self, mocked_time, Tester):
+        num_calls = 5
+        mocked_time.time = mock.Mock(side_effect=[1] * num_calls + [100])
+        MockAction = self.get_mock_action(
+            side_effect=ValueError("He's pining for the fjords!")
+        )
+
+        with pytest.raises(DeliveryError) as e:
+            Eventually(MockAction).perform_as(Tester)
+
+        assert f"{num_calls} times" in str(e)
 
     @mock.patch("screenpy.actions.eventually.time")
     def test_catches_exceptions(self, mocked_time, Tester):


### PR DESCRIPTION
This PR adds a count to `Eventually`, which counts how many attempts were performed during the timeout period. This should help with debugging in the case where the performable took longer than the timeout period, which might not be expected.