### PR TITLE
#3: Add negation-compatible aliases for `IsCloseTo` and `HasLength`.

### DIFF
--- a/docs/api/resolutions.rst
+++ b/docs/api/resolutions.rst
@@ -46,10 +46,14 @@ ContainsTheValue
 HasLength
 ---------
 
+**Aliases**: ``HaveLength``
+
 .. autoclass:: HasLength
 
 IsCloseTo
 ---------
+
+**Aliases**: ``CloseTo``
 
 .. autoclass:: IsCloseTo
 

--- a/screenpy/resolutions/__init__.py
+++ b/screenpy/resolutions/__init__.py
@@ -20,6 +20,7 @@ from .is_not import IsNot
 from .reads_exactly import ReadsExactly
 
 # Natural-language-enabling syntactic sugar
+CloseTo = IsCloseTo
 ContainTheEntry = ContainTheEntries = ContainsTheEntries = ContainsTheEntry
 ContainTheItem = ContainsTheItem
 ContainTheKey = ContainsTheKey
@@ -27,6 +28,7 @@ ContainTheText = ContainsTheText
 ContainTheValue = ContainsTheValue
 DoesNot = DoNot = IsNot
 Empty = IsEmpty
+HaveLength = HasLength
 IsEqual = Equals = Equal = EqualTo = IsEqualTo
 ReadExactly = ReadsExactly
 


### PR DESCRIPTION
Previously, you couldn't Englishly do an assertion that some value is not close to some expected value, or that a sequence does not have a certain length. You'd have to do `IsNot(IsCloseto(5))` or `DoesNot(HasLength(5))`. 🤢 

This PR fixes that by adding `CloseTo` and `HaveLength`, which follow "not" much nicelier!