### PR TITLE
#5: Fix typing for Pause.

### DIFF
--- a/screenpy/actions/pause.py
+++ b/screenpy/actions/pause.py
@@ -33,7 +33,7 @@ class Pause:
     time: float
 
     @classmethod
-    def for_(cls, number: int) -> "Pause":
+    def for_(cls, number: float) -> "Pause":
         """Specify how many seconds or milliseconds to wait for."""
         return cls(number)
 


### PR DESCRIPTION
For some reason, only the `for_` method of `Pause` had the time classed as an `int`, even though the `time` attribute had a `float` type and everything else expected a `float`. 🤷 

This PR fixes that!