### PR TITLE
#6: Clear an Actor's cleanup tasks even if they error out while performing them.

### DIFF
--- a/screenpy/actor.py
+++ b/screenpy/actor.py
@@ -4,12 +4,14 @@ about the state of the application, and assert Resolutions, all in the
 service of perfoming their roles.
 """
 
+import warnings
 from random import choice
 from typing import List, Text, Type, TypeVar
 
 from .exceptions import UnableToPerform
 from .pacing import aside
 from .protocols import Forgettable, Performable
+from .speech_tools import get_additive_description
 
 ENTRANCE_DIRECTIONS = [
     "{actor} appears from behind the backdrop!",
@@ -44,7 +46,8 @@ class Actor:
     """
 
     abilities: List[Forgettable]
-    cleanup_tasks: List[Performable]
+    ordered_cleanup_tasks: List[Performable]
+    independent_cleanup_tasks: List[Performable]
 
     @classmethod
     def named(cls, name: Text) -> "Actor":
@@ -61,10 +64,38 @@ class Actor:
 
     def has_cleanup_tasks(self, *tasks: Performable) -> "Actor":
         """Assign one or more tasks to the Actor to perform when exiting."""
-        self.cleanup_tasks.extend(tasks)
+        warnings.warn(
+            "This method is deprecated."
+            " Please use either `has_ordered_cleanup_tasks`"
+            " or `has_independent_cleanup_tasks` instead.",
+            DeprecationWarning,
+        )
+        return self.has_ordered_cleanup_tasks(*tasks)
+
+    def has_ordered_cleanup_tasks(self, *tasks: Performable) -> "Actor":
+        """Assign one or more tasks for the Actor to perform when exiting.
+
+        The tasks given to this method must be performed successfully in
+        order. If any task fails, any subsequent tasks will not be attempted
+        and will be discarded.
+        """
+        self.ordered_cleanup_tasks.extend(tasks)
         return self
 
-    with_cleanup_tasks = with_cleanup_task = has_cleanup_task = has_cleanup_tasks
+    has_cleanup_task = has_ordered_cleanup_tasks
+    with_cleanup_task = with_ordered_cleanup_tasks = has_ordered_cleanup_tasks
+
+    def has_independent_cleanup_tasks(self, *tasks: Performable) -> "Actor":
+        """Assign one or more tasks for the Actor to perform when exiting.
+
+        The tasks included through this method are assumed to be independent;
+        that is to say, all of them will be executed regardless of whether
+        previous ones were successful.
+        """
+        self.independent_cleanup_tasks.extend(tasks)
+        return self
+
+    with_independent_cleanup_tasks = has_independent_cleanup_tasks
 
     def uses_ability_to(self, ability: Type[T]) -> T:
         """Find the Ability referenced and return it, if the Actor is capable.
@@ -99,13 +130,33 @@ class Actor:
         """Perform an Action."""
         action.perform_as(self)
 
-    def cleans_up(self) -> None:
-        """Perform any scheduled clean-up tasks."""
+    def cleans_up_ordered_tasks(self) -> None:
+        """Perform ordered clean-up tasks."""
         try:
-            for task in self.cleanup_tasks:
+            for task in self.ordered_cleanup_tasks:
                 self.perform(task)
         finally:
-            self.cleanup_tasks = []
+            self.ordered_cleanup_tasks = []
+
+    def cleans_up_independent_tasks(self) -> None:
+        """Perform independent clean-up tasks."""
+        for task in self.independent_cleanup_tasks:
+            try:
+                self.perform(task)
+            except Exception as e:  # pylint: disable=broad-except
+                action = get_additive_description(task)
+                msg = (
+                    f"{self} encountered an error while attempting to {action}:"
+                    f"\n    {e}"
+                )
+                aside(msg)
+
+        self.independent_cleanup_tasks = []
+
+    def cleans_up(self) -> None:
+        """Perform any scheduled clean-up tasks."""
+        self.cleans_up_independent_tasks()
+        self.cleans_up_ordered_tasks()
 
     def exit(self) -> None:
         """Direct the Actor to forget all their Abilities."""
@@ -122,4 +173,5 @@ class Actor:
     def __init__(self, name: str) -> None:
         self.name = name
         self.abilities = []
-        self.cleanup_tasks = []
+        self.ordered_cleanup_tasks = []
+        self.independent_cleanup_tasks = []

--- a/screenpy/actor.py
+++ b/screenpy/actor.py
@@ -101,9 +101,11 @@ class Actor:
 
     def cleans_up(self) -> None:
         """Perform any scheduled clean-up tasks."""
-        for task in self.cleanup_tasks:
-            self.perform(task)
-        self.cleanup_tasks = []
+        try:
+            for task in self.cleanup_tasks:
+                self.perform(task)
+        finally:
+            self.cleanup_tasks = []
 
     def exit(self) -> None:
         """Direct the Actor to forget all their Abilities."""

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -1,9 +1,17 @@
+import warnings
 from unittest import mock
 
 import pytest
 
 from screenpy import Actor
 from screenpy.exceptions import UnableToPerform
+
+
+def get_mock_task():
+    """Get a describable mock task."""
+    task = mock.Mock()
+    task.describe.return_value = "A mocked task."
+    return task
 
 
 def test_can_be_instantiated():
@@ -49,30 +57,81 @@ def test_find_abilities():
 
 
 def test_performs_cleanup_tasks_when_exiting():
-    mocked_task = mock.Mock()
-    actor = Actor.named("Tester").with_cleanup_task(mocked_task)
+    mocked_ordered_task = get_mock_task()
+    mocked_independent_task = get_mock_task()
+    actor = Actor.named("Tester").with_cleanup_task(mocked_ordered_task)
+    actor.has_independent_cleanup_tasks(mocked_independent_task)
 
     actor.exit()
 
-    mocked_task.perform_as.assert_called_once_with(actor)
-    assert len(actor.cleanup_tasks) == 0
+    mocked_ordered_task.perform_as.assert_called_once_with(actor)
+    mocked_independent_task.perform_as.assert_called_once_with(actor)
+    assert len(actor.ordered_cleanup_tasks) == 0
+    assert len(actor.independent_cleanup_tasks) == 0
+
+
+def assert_has_cleanup_tasks_is_deprecated():
+    actor = Actor.named("Tester")
+
+    with warnings.catch_warnings(record=True) as w:
+        actor.has_cleanup_tasks(None)
+
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert "has_ordered_cleanup_tasks" in str(w[-1])
+    assert "has_independent_cleanup_tasks" in str(w[-1])
 
 
 def test_clears_cleanup_tasks():
-    mocked_task = mock.Mock()
-    mocked_task_with_exception = mock.Mock()
+    mocked_task = get_mock_task()
+    mocked_task_with_exception = get_mock_task()
     mocked_task_with_exception.perform_as.side_effect = ValueError(
         "I will not buy this record, it is scratched."
     )
     actor1 = Actor.named("Tester").with_cleanup_task(mocked_task)
+    actor1.has_independent_cleanup_tasks(mocked_task)
     actor2 = Actor.named("Tester").with_cleanup_task(mocked_task_with_exception)
+    actor2.has_independent_cleanup_tasks(mocked_task_with_exception)
 
     actor1.cleans_up()
     with pytest.raises(ValueError):
         actor2.cleans_up()
 
-    assert len(actor1.cleanup_tasks) == 0
-    assert len(actor2.cleanup_tasks) == 0
+    assert len(actor1.ordered_cleanup_tasks) == 0
+    assert len(actor2.ordered_cleanup_tasks) == 0
+    assert len(actor1.independent_cleanup_tasks) == 0
+    assert len(actor2.independent_cleanup_tasks) == 0
+
+
+def test_ordered_cleanup_stops_at_first_exception():
+    mocked_task = get_mock_task()
+    mocked_task_with_exception = get_mock_task()
+    mocked_task_with_exception.perform_as.side_effect = ValueError(
+        "Good night, a-ding ding ding ding..."
+    )
+    actor1 = Actor.named("Tester").with_ordered_cleanup_tasks(
+        mocked_task_with_exception, mocked_task
+    )
+
+    with pytest.raises(ValueError):
+        actor1.cleans_up()
+
+    mocked_task.perform_as.assert_not_called()
+
+
+def test_independent_cleanup_continues_through_exceptions():
+    mocked_task = get_mock_task()
+    mocked_task_with_exception = get_mock_task()
+    mocked_task_with_exception.perform_as.side_effect = ValueError(
+        "Sir Robin ran away."
+    )
+    actor1 = Actor.named("Tester").with_independent_cleanup_tasks(
+        mocked_task_with_exception, mocked_task
+    )
+
+    actor1.cleans_up()
+
+    mocked_task_with_exception.perform_as.assert_called_once()
+    mocked_task.perform_as.assert_called_once()
 
 
 def test_forgets_abilities_when_exiting():

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -70,7 +70,7 @@ def test_performs_cleanup_tasks_when_exiting():
     assert len(actor.independent_cleanup_tasks) == 0
 
 
-def assert_has_cleanup_tasks_is_deprecated():
+def test_assert_has_cleanup_tasks_is_deprecated():
     actor = Actor.named("Tester")
 
     with warnings.catch_warnings(record=True) as w:

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -58,6 +58,23 @@ def test_performs_cleanup_tasks_when_exiting():
     assert len(actor.cleanup_tasks) == 0
 
 
+def test_clears_cleanup_tasks():
+    mocked_task = mock.Mock()
+    mocked_task_with_exception = mock.Mock()
+    mocked_task_with_exception.perform_as.side_effect = ValueError(
+        "I will not buy this record, it is scratched."
+    )
+    actor1 = Actor.named("Tester").with_cleanup_task(mocked_task)
+    actor2 = Actor.named("Tester").with_cleanup_task(mocked_task_with_exception)
+
+    actor1.cleans_up()
+    with pytest.raises(ValueError):
+        actor2.cleans_up()
+
+    assert len(actor1.cleanup_tasks) == 0
+    assert len(actor2.cleanup_tasks) == 0
+
+
 def test_forgets_abilities_when_exiting():
     mocked_ability = mock.Mock()
     actor = Actor.named("Tester").who_can(mocked_ability)


### PR DESCRIPTION
When an Actor is cleaning up, sometimes one of their performables might raise an error. Previously, this would skip the part where the Actor's cleanup task list is cleared. If you had told the Actor to `clean_up` directly rather than relying on their `exit` logic to clean up, then they'd turn around and start cleaning up again when they actually `exit`. 

This PR puts the cleanup task clear in a `finally` block, so it happens no matter how clean things look.