### PR TITLE
#23: Add more string resolutions!

### DIFF
--- a/docs/api/resolutions.rst
+++ b/docs/api/resolutions.rst
@@ -6,6 +6,13 @@ These are the Resolutions included in ScreenPy.
 
 .. module:: screenpy.resolutions
 
+ContainsItemMatching
+--------------------
+
+**Aliases**: ``ContainItemMatching``
+
+.. autoclass:: ContainsItemMatching
+
 ContainsTheEntry
 ----------------
 

--- a/docs/api/resolutions.rst
+++ b/docs/api/resolutions.rst
@@ -96,6 +96,13 @@ IsNot
 
 .. autoclass:: IsNot
 
+Matches
+-------
+
+**Aliases**: ``Match``
+
+.. autoclass:: Matches
+
 ReadsExactly
 ------------
 

--- a/docs/api/resolutions.rst
+++ b/docs/api/resolutions.rst
@@ -109,3 +109,10 @@ ReadsExactly
 **Aliases**: ``ReadExactly``
 
 .. autoclass:: ReadsExactly
+
+StartsWith
+----------
+
+**Aliases**: ``StartWith``
+
+.. autoclass:: StartsWith

--- a/docs/api/resolutions.rst
+++ b/docs/api/resolutions.rst
@@ -50,6 +50,13 @@ ContainsTheValue
 
 .. autoclass:: ContainsTheValue
 
+EndsWith
+--------
+
+**Aliases**: ``EndWith``
+
+.. autoclass:: EndsWith
+
 HasLength
 ---------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/screenpy/resolutions/__init__.py
+++ b/screenpy/resolutions/__init__.py
@@ -21,6 +21,7 @@ from .is_equal_to import IsEqualTo
 from .is_not import IsNot
 from .matches import Matches
 from .reads_exactly import ReadsExactly
+from .starts_with import StartsWith
 
 # Natural-language-enabling syntactic sugar
 CloseTo = IsCloseTo
@@ -37,6 +38,7 @@ HaveLength = HasLength
 IsEqual = Equals = Equal = EqualTo = IsEqualTo
 Match = Matches
 ReadExactly = ReadsExactly
+StartWith = StartsWith
 
 
 __all__ = [
@@ -73,4 +75,6 @@ __all__ = [
     "Matches",
     "ReadExactly",
     "ReadsExactly",
+    "StartsWith",
+    "StartWith",
 ]

--- a/screenpy/resolutions/__init__.py
+++ b/screenpy/resolutions/__init__.py
@@ -13,6 +13,7 @@ from .contains_the_item import ContainsTheItem
 from .contains_the_key import ContainsTheKey
 from .contains_the_text import ContainsTheText
 from .contains_the_value import ContainsTheValue
+from .ends_with import EndsWith
 from .has_length import HasLength
 from .is_close_to import IsCloseTo
 from .is_empty import IsEmpty
@@ -30,6 +31,7 @@ ContainTheText = ContainsTheText
 ContainTheValue = ContainsTheValue
 DoesNot = DoNot = IsNot
 Empty = IsEmpty
+EndWith = EndsWith
 HaveLength = HasLength
 IsEqual = Equals = Equal = EqualTo = IsEqualTo
 ReadExactly = ReadsExactly
@@ -54,6 +56,8 @@ __all__ = [
     "DoesNot",
     "DoNot",
     "Empty",
+    "EndsWith",
+    "EndWith",
     "Equal",
     "Equals",
     "EqualTo",

--- a/screenpy/resolutions/__init__.py
+++ b/screenpy/resolutions/__init__.py
@@ -19,6 +19,7 @@ from .is_close_to import IsCloseTo
 from .is_empty import IsEmpty
 from .is_equal_to import IsEqualTo
 from .is_not import IsNot
+from .matches import Matches
 from .reads_exactly import ReadsExactly
 
 # Natural-language-enabling syntactic sugar
@@ -34,6 +35,7 @@ Empty = IsEmpty
 EndWith = EndsWith
 HaveLength = HasLength
 IsEqual = Equals = Equal = EqualTo = IsEqualTo
+Match = Matches
 ReadExactly = ReadsExactly
 
 
@@ -67,6 +69,8 @@ __all__ = [
     "IsEqual",
     "IsEqualTo",
     "IsNot",
+    "Match",
+    "Matches",
     "ReadExactly",
     "ReadsExactly",
 ]

--- a/screenpy/resolutions/__init__.py
+++ b/screenpy/resolutions/__init__.py
@@ -7,6 +7,7 @@ first half is handled by Questions.
 """
 
 from .base_resolution import BaseResolution
+from .contains_item_matching import ContainsItemMatching
 from .contains_the_entry import ContainsTheEntry
 from .contains_the_item import ContainsTheItem
 from .contains_the_key import ContainsTheKey
@@ -21,6 +22,7 @@ from .reads_exactly import ReadsExactly
 
 # Natural-language-enabling syntactic sugar
 CloseTo = IsCloseTo
+ContainItemMatching = ContainsItemMatching
 ContainTheEntry = ContainTheEntries = ContainsTheEntries = ContainsTheEntry
 ContainTheItem = ContainsTheItem
 ContainTheKey = ContainsTheKey
@@ -35,6 +37,8 @@ ReadExactly = ReadsExactly
 
 __all__ = [
     "BaseResolution",
+    "ContainItemMatching",
+    "ContainsItemMatching",
     "ContainsTheEntries",
     "ContainsTheEntry",
     "ContainsTheItem",

--- a/screenpy/resolutions/contains_item_matching.py
+++ b/screenpy/resolutions/contains_item_matching.py
@@ -1,0 +1,28 @@
+"""
+Matches a sequence which contains an item matching a given regex pattern.
+"""
+
+from .base_resolution import BaseResolution
+from .custom_matchers.sequence_containing_pattern import (
+    IsSequenceContainingPattern,
+    has_item_matching,
+)
+
+
+class ContainsItemMatching(BaseResolution):
+    """Match a sequence containing an item matching a regular expression.
+
+    Examples::
+
+        the_actor.should(
+            # matches "Spam...", "Spam spam...", "Spam spam spam..."
+            See.the(Text.of_all(MENU_ITEMS), ContainsItemMatching(r"^([Ss]pam ?)+"))
+        )
+    """
+
+    matcher: IsSequenceContainingPattern
+    line = 'a sequence with an item matching the regular expression "{expectation}".'
+    matcher_function = has_item_matching
+
+    def __init__(self, match: str) -> None:
+        super().__init__(match)

--- a/screenpy/resolutions/custom_matchers/sequence_containing_pattern.py
+++ b/screenpy/resolutions/custom_matchers/sequence_containing_pattern.py
@@ -1,0 +1,52 @@
+"""
+Matcher to use a regular expression pattern to match an item in a sequence.
+"""
+
+import re
+from typing import Sequence
+
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.description import Description
+from hamcrest.core.matcher import Matcher
+
+
+class IsSequenceContainingPattern(BaseMatcher[Sequence[str]]):
+    """Matcher to test each string in a sequence against a regex."""
+
+    def __init__(self, pattern: str) -> None:
+        self.pattern = pattern
+
+    def _matches(self, item: Sequence[str]) -> bool:
+        try:
+            for element in item:
+                if re.match(self.pattern, element):
+                    return True
+        except TypeError:  # not a sequence
+            pass
+        return False
+
+    def describe_to(self, description: Description) -> None:
+        """Describe the passing case."""
+        description.append_text(
+            f"a sequence containing an element which matches {self.pattern}"
+        )
+
+    def describe_match(self, _: Sequence[str], match_description: Description) -> None:
+        """Describe the match, for use with IsNot."""
+        match_description.append_text(f'it contains an item matching "{self.pattern}"')
+
+    def describe_mismatch(
+        self, item: Sequence[str], mismatch_description: Description
+    ) -> None:
+        """Describe the failing case."""
+        if item is None or not hasattr(item, "__iter__"):
+            mismatch_description.append_text("was not a sequence")
+            return
+        mismatch_description.append_text(
+            f"did not contain an item matching {self.pattern}"
+        )
+
+
+def has_item_matching(pattern: str) -> Matcher[Sequence[str]]:
+    """Matches if any element of sequence matches the regex pattern."""
+    return IsSequenceContainingPattern(pattern)

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -1,0 +1,26 @@
+"""
+Matches a string which ends with a substring.
+"""
+
+from hamcrest import ends_with
+from hamcrest.library.text.stringendswith import StringEndsWith
+
+from .base_resolution import BaseResolution
+
+
+class EndsWith(BaseResolution):
+    """Match a string which ends with the given substring.
+
+    Examples::
+
+        the_actor.should(
+            See.the(Text.of_the(LOGIN_ERROR), EndsWith("username or password."))
+        )
+    """
+
+    matcher: StringEndsWith
+    line = 'text ending with "{expectation}".'
+    matcher_function = ends_with
+
+    def __init__(self, match: str) -> None:
+        super().__init__(match)

--- a/screenpy/resolutions/matches.py
+++ b/screenpy/resolutions/matches.py
@@ -1,0 +1,27 @@
+"""
+Matches a string using a regex pattern.
+"""
+
+from hamcrest import matches_regexp
+from hamcrest.library.text.stringmatches import StringMatchesPattern
+
+from .base_resolution import BaseResolution
+
+
+class Matches(BaseResolution):
+    """Match a string using a regular expression.
+
+    Examples::
+
+        the_actor.should(
+            # matches "/product/1", "/product/22", "/product/942"...
+            See.the(Text.of_the(URL), Matches(r"/product/[0-9]{1,3}"))
+        )
+    """
+
+    matcher: StringMatchesPattern
+    line = 'text matching the regular expression "{expectation}".'
+    matcher_function = matches_regexp
+
+    def __init__(self, match: str) -> None:
+        super().__init__(match)

--- a/screenpy/resolutions/starts_with.py
+++ b/screenpy/resolutions/starts_with.py
@@ -1,0 +1,26 @@
+"""
+Matches a string which begins with a substring.
+"""
+
+from hamcrest import starts_with
+from hamcrest.library.text.stringstartswith import StringStartsWith
+
+from .base_resolution import BaseResolution
+
+
+class StartsWith(BaseResolution):
+    """Match a string which starts with the given substring.
+
+    Examples::
+
+        the_actor.should(
+            See.the(Text.of_the(WELCOME_MESSAGE), StartsWith("Welcome"))
+        )
+    """
+
+    matcher: StringStartsWith
+    line = 'text starting with "{expectation}".'
+    matcher_function = starts_with
+
+    def __init__(self, match: str) -> None:
+        super().__init__(match)

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -20,6 +20,7 @@ from screenpy.resolutions import (
     IsNot,
     Matches,
     ReadsExactly,
+    StartsWith,
 )
 from screenpy.resolutions.base_resolution import BaseMatcher
 
@@ -356,3 +357,19 @@ class TestReadsExactly:
 
     def test_type_hint(self) -> None:
         assert_matcher_annotation(ReadsExactly("hi"))
+
+
+class TestStartsWith:
+    def test_can_be_instantiated(self) -> None:
+        sw = StartsWith("")
+
+        assert isinstance(sw, StartsWith)
+
+    def test_the_test(self) -> None:
+        sw = StartsWith("I will not buy this record")
+
+        assert sw.matches("I will not buy this record, it is scratched.")
+        assert not sw.matches("I will not buy this tobacconist, it is scratched.")
+
+    def test_type_hint(self) -> None:
+        assert_matcher_annotation(StartsWith(""))

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -11,6 +11,7 @@ from screenpy.resolutions import (
     ContainsTheText,
     ContainsTheValue,
     DoesNot,
+    EndsWith,
     Equal,
     HasLength,
     IsCloseTo,
@@ -228,6 +229,22 @@ class TestEmpty:
 
     def test_type_hint(self) -> None:
         assert_matcher_annotation(IsEmpty())
+
+
+class TestEndsWith:
+    def test_can_be_instantiated(self) -> None:
+        ew = EndsWith("")
+
+        assert isinstance(ew, EndsWith)
+
+    def test_the_test(self) -> None:
+        ew = EndsWith("of life!")
+
+        assert ew.matches("Bereft of life!")
+        assert not ew.matches("He has ceased to be!")
+
+    def test_type_hint(self) -> None:
+        assert_matcher_annotation(EndsWith(""))
 
 
 class TestHasLength:

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -18,6 +18,7 @@ from screenpy.resolutions import (
     IsEmpty,
     IsEqualTo,
     IsNot,
+    Matches,
     ReadsExactly,
 )
 from screenpy.resolutions.base_resolution import BaseMatcher
@@ -322,6 +323,22 @@ class TestIsNot:
 
     def test_type_hint(self) -> None:
         assert_matcher_annotation(IsNot(1))
+
+
+class TestMatches:
+    def test_can_be_instantiated(self) -> None:
+        m = Matches(r"^$")
+
+        assert isinstance(m, Matches)
+
+    def test_the_test(self) -> None:
+        m = Matches(r"([Ss]pam ?)+")
+
+        assert m.matches("Spam spam spam spam baked beans and spam")
+        assert not m.matches("What do you mean Eugh?!")
+
+    def test_type_hint(self) -> None:
+        assert_matcher_annotation(Matches(r"^$"))
 
 
 class TestReadsExactly:

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -4,6 +4,7 @@ import pytest
 
 from screenpy.resolutions import (
     BaseResolution,
+    ContainsItemMatching,
     ContainsTheEntry,
     ContainsTheItem,
     ContainsTheKey,
@@ -94,6 +95,22 @@ class TestBaseResolution:
         repr(resolution)
 
         resolution.get_line.assert_called_once()
+
+
+class TestContainsItemMatching:
+    def test_can_be_instantiated(self) -> None:
+        cim = ContainsItemMatching(r"^$")
+
+        assert isinstance(cim, ContainsItemMatching)
+
+    def test_the_test(self) -> None:
+        cim = ContainsItemMatching(r"([Ss]pam ?)+")
+
+        assert cim.matches(["Spam", "Eggs", "Spam and eggs"])
+        assert not cim.matches(["Porridge"])
+
+    def test_type_hint(self) -> None:
+        assert_matcher_annotation(ContainsItemMatching(r"^$"))
 
 
 class TestContainsTheEntry:

--- a/tox.ini
+++ b/tox.ini
@@ -4,21 +4,23 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = 
-    py37
+envlist =
     py38
     py39
     py310
+    py311
 isolated_build = True
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
+whitelist_externals =
+    coverage
 extras =
     test
 commands =


### PR DESCRIPTION
This PR adds the following Resolutions to the set:
* `ContainsItemMatching` (matches a sequence of strings using a regular expression)
* `EndsWith` (matches a string which ends with a given substring)
* `Matches` (matches a string using a regular expression)
* `StartsWith` (matches a string which begins with a given substring)

I also fixed a small error in our docs ("language" was set to `None`, Sphinx doesn't like that anymore) and updated `tox.ini` to remove Python 3.7.