### PR TITLE
Refactor Resolutions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+extend-ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ files: '(screenpy|examples)/.*'
 fail_fast: false
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 23.1.0
   hooks:
   - id: black
     language_version: python3.11
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.11.5
+  rev: 5.12.0
   hooks:
   - id: isort
     language_version: python3.11
@@ -17,7 +17,7 @@ repos:
   - id: flake8
     language_version: python3.11
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.991
+  rev: v1.1.1
   hooks:
   - id: mypy
     language_version: python3.11

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,7 @@ disable=
     logging-format-interpolation,
     logging-fstring-interpolation,
     no-member,
+    no-self-use,
     super-init-not-called,
     too-few-public-methods,
     unused-argument,

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -35,6 +35,13 @@ Question
     :members:
     :undoc-members:
 
+Resolution
+----------
+
+.. autoclass:: Resolvable
+    :members:
+    :undoc-members:
+
 Narrator's Adapter
 ------------------
 

--- a/docs/api/resolutions.rst
+++ b/docs/api/resolutions.rst
@@ -151,3 +151,9 @@ StartsWith
 **Aliases**: ``StartWith``
 
 .. autoclass:: StartsWith
+
+
+BaseResolution
+--------------
+
+.. autoclass:: BaseResolution

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -8,6 +8,89 @@ in ScreenPy's life,
 and how to adjust your tests
 to keep them up to date.
 
+4.2.0 Deprecations
+==================
+
+:class:`~screenpy.resolutions.base_resolution.BaseResolution` is now deprecated.
+
+For a long time,
+``BaseResolution`` was an odd duck.
+All the other pieces of ScreenPy are some sort of -able:
+Performable.
+Answerable.
+Describable.
+Resolutions,
+though,
+were some strange inheritance.
+
+Not anymore!
+Now Resolutions are :class:`~screenpy.protocols.Resolvable`!
+This hopefully makes them easier to understand.
+
+Please update your custom Resolutions by making them Resolvable.
+Here is an example of :class:`~screenpy.resolutions.IsEqualTo`
+before and after this change.
+
+Before::
+
+    from typing import TypeVar
+
+    from hamcrest import equal_to
+    from hamcrest.core.core.isequal import IsEqual
+
+    from .base_resolution import BaseResolution
+
+    T = TypeVar("T")
+
+
+    class IsEqualTo(BaseResolution):
+        """Match on an equal object.
+        Examples::
+            the_actor.should(
+                See.the(Number.of(ADVERTISEMENT_BANNERS), IsEqualTo(0))
+            )
+        """
+
+        matcher: IsEqual
+        line = "equal to {expectation}"
+        matcher_function = equal_to
+
+        def __init__(self, obj: T) -> None:
+            super().__init__(obj)
+
+After::
+
+    from typing import Any
+
+    from hamcrest import equal_to
+    from hamcrest.core.matcher import Matcher
+
+    from screenpy.pacing import beat
+
+
+    class IsEqualTo:
+        """Match on an equal object.
+
+        Examples::
+
+            the_actor.should(
+                See.the(Number.of(ADVERTISEMENT_BANNERS), IsEqualTo(0))
+            )
+        """
+
+        def describe(self) -> str:
+            """Describe the Resolution's expectation."""
+            return f"Equal to {self.expected}."
+
+        @beat("... hoping it's equal to {expected}.")
+        def resolve(self) -> Matcher[Any]:
+            """Produce the Matcher to make the assertion."""
+            return equal_to(self.expected)
+
+        def __init__(self, obj: Any) -> None:
+            self.expected = obj
+
+
 4.0.0 Breaking Changes
 ======================
 

--- a/docs/example/resolutions.rst
+++ b/docs/example/resolutions.rst
@@ -18,18 +18,10 @@ One used the built-in :class:`~screenpy.resolutions.Equals` Resolution,
 while the other used a custom ``IsPalpable`` Resolution.
 Let's examine the latter.
 
-Resolutions all inherit
-from the :class:`~screenpy.resolutions.BaseResolution` class.
-All that is needed
-is a ``line`` and a "matcher" function.
-
-The ``line`` appears in the log.
-Write the line such that
-it describes the expected value
-while completing the sentence,
-"Hoping it's...".
-You can use ``{expectation}`` here
-to reference the expected value.
+Resolutions are :class:`~screenpy.protocols.Resolvable`.
+This means they have a ``resolve`` method,
+which calls and returns a "matcher" function
+for the assertion.
 
 The "matcher" function
 can come from `PyHamcrest <https://github.com/hamcrest/PyHamcrest#pyhamcrest>`__,
@@ -83,7 +75,8 @@ Here's how those might be assembled::
 .. code-block:: python
 
     # resolutions/is_palpable.py
-    from screenpy.resolutions import BaseResolution
+    from hamcrest.core.matcher import Matcher
+    from screenpy.pacing import beat
 
     from .matchers.has_saturation_greater_than import is_palpable
 
@@ -95,8 +88,11 @@ Here's how those might be assembled::
 
             the_actor.should(See.the(AudienceTension(), IsPalpable()))
         """
-        line = "a palpable tension!"
-        matcher_function = is_palpable
+
+        @beat("... hoping it's a palpable tension!")
+        def resolve(self) -> Matcher[str]:
+            """Provide the Matcher to make the assertion."""
+            return is_palpable()
 
 
 That's really all there is

--- a/screenpy/actions/see.py
+++ b/screenpy/actions/see.py
@@ -36,12 +36,12 @@ class See:
 
     question: T_Q
     question_to_log: str
-    resolution: BaseResolution | Resolvable
+    resolution: Union[BaseResolution, Resolvable]
     resolution_to_log: str
 
     @classmethod
     def the(
-        cls: Type[SelfSee], question: T_Q, resolution: BaseResolution | Resolvable
+        cls: Type[SelfSee], question: T_Q, resolution: Union[BaseResolution, Resolvable]
     ) -> SelfSee:
         """Supply the Question (or value) and Resolution to test."""
         return cls(question, resolution)
@@ -72,7 +72,7 @@ class See:
         assert_that(value, matcher, reason)
 
     def __init__(
-        self: SelfSee, question: T_Q, resolution: BaseResolution | Resolvable
+        self: SelfSee, question: T_Q, resolution: Union[BaseResolution, Resolvable]
     ) -> None:
         self.question = question
         self.question_to_log = get_additive_description(question)

--- a/screenpy/actions/see.py
+++ b/screenpy/actions/see.py
@@ -64,12 +64,7 @@ class See:
         if isinstance(self.question, ErrorKeeper):
             reason = f"{self.question.caught_exception}"
 
-        if isinstance(self.resolution, Resolvable):
-            matcher = self.resolution.resolve()
-        else:
-            matcher = self.resolution
-
-        assert_that(value, matcher, reason)
+        assert_that(value, self.resolution.resolve(), reason)
 
     def __init__(
         self: SelfSee, question: T_Q, resolution: Union[BaseResolution, Resolvable]

--- a/screenpy/actions/see.py
+++ b/screenpy/actions/see.py
@@ -9,11 +9,11 @@ from hamcrest import assert_that
 from screenpy import Actor
 from screenpy.pacing import aside, beat
 from screenpy.protocols import Answerable, ErrorKeeper, Resolvable
-from screenpy.resolutions import BaseResolution
 from screenpy.speech_tools import get_additive_description
 
 SelfSee = TypeVar("SelfSee", bound="See")
 T_Q = Union[Answerable, object]
+T_R = Resolvable
 
 
 class See:
@@ -36,13 +36,11 @@ class See:
 
     question: T_Q
     question_to_log: str
-    resolution: Union[BaseResolution, Resolvable]
+    resolution: T_R
     resolution_to_log: str
 
     @classmethod
-    def the(
-        cls: Type[SelfSee], question: T_Q, resolution: Union[BaseResolution, Resolvable]
-    ) -> SelfSee:
+    def the(cls: Type[SelfSee], question: T_Q, resolution: T_R) -> SelfSee:
         """Supply the Question (or value) and Resolution to test."""
         return cls(question, resolution)
 
@@ -66,9 +64,7 @@ class See:
 
         assert_that(value, self.resolution.resolve(), reason)
 
-    def __init__(
-        self: SelfSee, question: T_Q, resolution: Union[BaseResolution, Resolvable]
-    ) -> None:
+    def __init__(self: SelfSee, question: T_Q, resolution: T_R) -> None:
         self.question = question
         self.question_to_log = get_additive_description(question)
         self.resolution = resolution

--- a/screenpy/actions/see_all_of.py
+++ b/screenpy/actions/see_all_of.py
@@ -3,17 +3,16 @@ Make several assertions using any number of Question and Resolution tuples,
 all of which are expected to be true.
 """
 
-from typing import Tuple, Type, TypeVar, Union
+from typing import Tuple, Type, TypeVar
 
 from screenpy import Actor
 from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
-from screenpy.protocols import Answerable, Resolvable
 
-from .see import See
+from .see import T_Q, T_R, See
 
 SelfSeeAllOf = TypeVar("SelfSeeAllOf", bound="SeeAllOf")
-T_T = Tuple[Union[Answerable, object], Resolvable]
+T_T = Tuple[T_Q, T_R]
 
 
 class SeeAllOf:

--- a/screenpy/actions/see_all_of.py
+++ b/screenpy/actions/see_all_of.py
@@ -8,13 +8,12 @@ from typing import Tuple, Type, TypeVar, Union
 from screenpy import Actor
 from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
-from screenpy.protocols import Answerable
-from screenpy.resolutions import BaseResolution
+from screenpy.protocols import Answerable, Resolvable
 
 from .see import See
 
 SelfSeeAllOf = TypeVar("SelfSeeAllOf", bound="SeeAllOf")
-T_T = Tuple[Union[Answerable, object], BaseResolution]
+T_T = Tuple[Union[Answerable, object], Resolvable]
 
 
 class SeeAllOf:

--- a/screenpy/actions/see_any_of.py
+++ b/screenpy/actions/see_any_of.py
@@ -3,17 +3,16 @@ Make several assertions using any number of Question and Resolution tuples,
 at least one of which is expected to be true.
 """
 
-from typing import Tuple, Type, TypeVar, Union
+from typing import Tuple, Type, TypeVar
 
 from screenpy import Actor
 from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
-from screenpy.protocols import Answerable, Resolvable
 
-from .see import See
+from .see import T_Q, T_R, See
 
 SelfSeeAnyOf = TypeVar("SelfSeeAnyOf", bound="SeeAnyOf")
-T_T = Tuple[Union[Answerable, object], Resolvable]
+T_T = Tuple[T_Q, T_R]
 
 
 class SeeAnyOf:

--- a/screenpy/actions/see_any_of.py
+++ b/screenpy/actions/see_any_of.py
@@ -8,13 +8,12 @@ from typing import Tuple, Type, TypeVar, Union
 from screenpy import Actor
 from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
-from screenpy.protocols import Answerable
-from screenpy.resolutions import BaseResolution
+from screenpy.protocols import Answerable, Resolvable
 
 from .see import See
 
 SelfSeeAnyOf = TypeVar("SelfSeeAnyOf", bound="SeeAnyOf")
-T_T = Tuple[Union[Answerable, object], BaseResolution]
+T_T = Tuple[Union[Answerable, object], Resolvable]
 
 
 class SeeAnyOf:

--- a/screenpy/exceptions.py
+++ b/screenpy/exceptions.py
@@ -41,3 +41,11 @@ class QuestionError(ScreenPyError):
 
 class UnableToAnswer(QuestionError):
     """The Question is not answerable."""
+
+
+class ResolutionError(ScreenPyError):
+    """These errors are raised when a Resolution fails."""
+
+
+class UnableToFormResolution(ResolutionError):
+    """The Resolution is unable to be formed."""

--- a/screenpy/protocols.py
+++ b/screenpy/protocols.py
@@ -10,6 +10,7 @@ https://mypy.readthedocs.io/en/stable/protocols.html
 
 from typing import TYPE_CHECKING, Any, Callable, Generator, Optional
 
+from hamcrest.core.base_matcher import Matcher
 from typing_extensions import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -33,6 +34,21 @@ class Answerable(Protocol):
         Returns:
             The answer, based on the sleuthing the Actor has done.
         """
+
+
+@runtime_checkable
+class Describable(Protocol):
+    """Classes that describe themselves are Describable"""
+
+    def describe(self) -> str:
+        """Describe the Describable in the present tense."""
+
+
+@runtime_checkable
+class ErrorKeeper(Protocol):
+    """Classes that save exceptions for later are ErrorKeeper(s)"""
+
+    caught_exception: Optional[Exception]
 
 
 @runtime_checkable
@@ -60,18 +76,15 @@ class Performable(Protocol):
 
 
 @runtime_checkable
-class ErrorKeeper(Protocol):
-    """Classes that save exceptions for later are ErrorKeeper(s)"""
+class Resolvable(Protocol):
+    """Resolutions are Resolvable"""
 
-    caught_exception: Optional[Exception]
+    def resolve(self) -> Matcher:
+        """Form the Matcher for an assertion.
 
-
-@runtime_checkable
-class Describable(Protocol):
-    """Classes that describe themselves are Describable"""
-
-    def describe(self) -> str:
-        """Describe the Describable in the present tense."""
+        Returns:
+            Matcher: the Matcher this Resolution uses for the expected value.
+        """
 
 
 @runtime_checkable

--- a/screenpy/resolutions/base_resolution.py
+++ b/screenpy/resolutions/base_resolution.py
@@ -42,6 +42,10 @@ class BaseResolution(BaseMatcher[T]):
         'phrase: "hoping it\'s...".'
     )
 
+    def describe(self) -> str:
+        """Describe the Resolution in present tense."""
+        return self.get_line().capitalize()
+
     @beat("... hoping it's {motivation}")
     def _matches(self, item: T) -> bool:
         """passthrough to the matcher's method."""

--- a/screenpy/resolutions/base_resolution.py
+++ b/screenpy/resolutions/base_resolution.py
@@ -12,6 +12,7 @@ with a Question to get the actual value. An assertion might look like:
     )
 """
 
+import warnings
 from typing import Any, Callable, TypeVar
 
 from hamcrest.core.base_matcher import BaseMatcher, Matcher
@@ -30,7 +31,7 @@ class BaseResolution(BaseMatcher[T]):
 
     You probably shouldn't expect to call any of the defined methods on
     this class or any inherited classes. Just pass an instantiated
-    Resolution to your |Actor|, they'll know what to do with it.
+    Resolution to your Actor, they'll know what to do with it.
     """
 
     matcher: Matcher
@@ -77,6 +78,12 @@ class BaseResolution(BaseMatcher[T]):
         return self.get_line()
 
     def __init__(self, *args: object, **kwargs: object) -> None:
+        warnings.warn(
+            "BaseResolution is deprecated and will be removed in ScreenPy v5.0.0."
+            " Please make your Resolution Resolvable instead."
+            "\nSee https://screenpy-docs.readthedocs.io/en/latest/deprecations.html",
+            DeprecationWarning,
+        )
         cls = self.__class__
         if args and kwargs:
             self.expected = (args, kwargs)

--- a/screenpy/resolutions/base_resolution.py
+++ b/screenpy/resolutions/base_resolution.py
@@ -43,8 +43,12 @@ class BaseResolution(BaseMatcher[T]):
     )
 
     def describe(self) -> str:
-        """Describe the Resolution in present tense."""
+        """Describe the Resolution's expectation."""
         return self.get_line().capitalize()
+
+    def resolve(self) -> BaseMatcher[T]:
+        """Produce the Matcher to make the assertion."""
+        return self
 
     @beat("... hoping it's {motivation}")
     def _matches(self, item: T) -> bool:

--- a/screenpy/resolutions/contains_item_matching.py
+++ b/screenpy/resolutions/contains_item_matching.py
@@ -4,7 +4,7 @@ Matches a sequence which contains an item matching a given regex pattern.
 
 from typing import Sequence, TypeVar
 
-from hamcrest.core.base_matcher import Matcher
+from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
 

--- a/screenpy/resolutions/contains_item_matching.py
+++ b/screenpy/resolutions/contains_item_matching.py
@@ -2,17 +2,13 @@
 Matches a sequence which contains an item matching a given regex pattern.
 """
 
-from typing import Sequence, TypeVar
+from typing import Sequence
 
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
 
 from .custom_matchers.sequence_containing_pattern import has_item_matching
-
-SelfContainsItemMatching = TypeVar(
-    "SelfContainsItemMatching", bound="ContainsItemMatching"
-)
 
 
 class ContainsItemMatching:
@@ -26,14 +22,14 @@ class ContainsItemMatching:
         )
     """
 
-    def describe(self: SelfContainsItemMatching) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'A sequence with an item matching the pattern r"{self.pattern}".'
 
     @beat('... hoping it contains an item matching the pattern r"{pattern}".')
-    def resolve(self: SelfContainsItemMatching) -> Matcher[Sequence[str]]:
+    def resolve(self) -> Matcher[Sequence[str]]:
         """Produce the Matcher to make the assertion."""
         return has_item_matching(self.pattern)
 
-    def __init__(self: SelfContainsItemMatching, pattern: str) -> None:
+    def __init__(self, pattern: str) -> None:
         self.pattern = pattern

--- a/screenpy/resolutions/contains_item_matching.py
+++ b/screenpy/resolutions/contains_item_matching.py
@@ -27,10 +27,10 @@ class ContainsItemMatching:
     """
 
     def describe(self: SelfContainsItemMatching) -> str:
-        """Describe the Resolution in present tense."""
-        return f"Match the pattern {self.pattern}."
+        """Describe the Resolution's expectation."""
+        return f'A sequence with an item matching the pattern r"{self.pattern}".'
 
-    @beat('... hoping it contains an item matching the pattern "{pattern}".')
+    @beat('... hoping it contains an item matching the pattern r"{pattern}".')
     def resolve(self: SelfContainsItemMatching) -> Matcher[Sequence[str]]:
         """Produce the Matcher to make the assertion."""
         return has_item_matching(self.pattern)

--- a/screenpy/resolutions/contains_item_matching.py
+++ b/screenpy/resolutions/contains_item_matching.py
@@ -2,14 +2,20 @@
 Matches a sequence which contains an item matching a given regex pattern.
 """
 
-from .base_resolution import BaseResolution
-from .custom_matchers.sequence_containing_pattern import (
-    IsSequenceContainingPattern,
-    has_item_matching,
+from typing import Sequence, TypeVar
+
+from hamcrest.core.base_matcher import Matcher
+
+from screenpy.pacing import beat
+
+from .custom_matchers.sequence_containing_pattern import has_item_matching
+
+SelfContainsItemMatching = TypeVar(
+    "SelfContainsItemMatching", bound="ContainsItemMatching"
 )
 
 
-class ContainsItemMatching(BaseResolution):
+class ContainsItemMatching:
     """Match a sequence containing an item matching a regular expression.
 
     Examples::
@@ -20,9 +26,14 @@ class ContainsItemMatching(BaseResolution):
         )
     """
 
-    matcher: IsSequenceContainingPattern
-    line = 'a sequence with an item matching the regular expression "{expectation}".'
-    matcher_function = has_item_matching
+    def describe(self: SelfContainsItemMatching) -> str:
+        """Describe the Resolution in present tense."""
+        return f"Match the pattern {self.pattern}."
 
-    def __init__(self, match: str) -> None:
-        super().__init__(match)
+    @beat('... hoping it contains an item matching the pattern "{pattern}".')
+    def resolve(self: SelfContainsItemMatching) -> Matcher[Sequence[str]]:
+        """Produce the Matcher to make the assertion."""
+        return has_item_matching(self.pattern)
+
+    def __init__(self: SelfContainsItemMatching, pattern: str) -> None:
+        self.pattern = pattern

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -12,7 +12,6 @@ from screenpy.pacing import beat
 
 from .base_resolution import BaseResolution
 
-SelfContainsTheEntry = TypeVar("SelfContainsTheEntry", bound="ContainsTheEntry")
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
@@ -29,31 +28,31 @@ class ContainsTheEntry(BaseResolution):
         )
     """
 
-    def describe(self: SelfContainsTheEntry) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"A mapping with the entries {self.entries_to_log}."
 
     @beat("... hoping it's a mapping with the entries {entries_to_log}")
-    def resolve(self: SelfContainsTheEntry) -> Matcher[Mapping]:
+    def resolve(self) -> Matcher[Mapping]:
         """Produce the Matcher to make the assertion."""
         return has_entries(**self.entries)
 
     # Keyword argument form
     @overload
-    def __init__(self: SelfContainsTheEntry, **kv_args: V) -> None:
+    def __init__(self, **kv_args: V) -> None:
         ...
 
     # Key to value dict form
     @overload
-    def __init__(self: SelfContainsTheEntry, kv_args: Mapping[K, V]) -> None:
+    def __init__(self, kv_args: Mapping[K, V]) -> None:
         ...
 
     # Alternating key/value form
     @overload
-    def __init__(self: SelfContainsTheEntry, *kv_args: Any) -> None:
+    def __init__(self, *kv_args: Any) -> None:
         ...
 
-    def __init__(self: SelfContainsTheEntry, *kv_args: Any, **kv_kwargs: Any) -> None:
+    def __init__(self, *kv_args: Any, **kv_kwargs: Any) -> None:
         if len(kv_args) > 1 and len(kv_args) % 2 == 1:
             msg = f"{self.__class__.__name__} could not pair {kv_args}."
             msg += " Make sure they're paired up properly!"

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -2,13 +2,17 @@
 Matches a dictionary that contains the specified key/value pair(s).
 """
 
-from typing import Any, Hashable, Mapping, TypeVar, overload
+from typing import Any, Hashable, Iterable, Mapping, Tuple, TypeVar, overload
 
 from hamcrest import has_entries
-from hamcrest.library.collection.isdict_containingentries import IsDictContainingEntries
+from hamcrest.core.matcher import Matcher
+
+from screenpy.exceptions import UnableToFormResolution
+from screenpy.pacing import beat
 
 from .base_resolution import BaseResolution
 
+SelfContainsTheEntry = TypeVar("SelfContainsTheEntry", bound="ContainsTheEntry")
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
@@ -25,24 +29,54 @@ class ContainsTheEntry(BaseResolution):
         )
     """
 
-    matcher: IsDictContainingEntries
-    line = "a dict containing {expectation}"
-    matcher_function = has_entries
+    def describe(self: SelfContainsTheEntry) -> str:
+        """Describe the Resolution in the present tense."""
+        return f"Contain the entries {self.entries_to_log}."
+
+    @beat("... hoping it's a dict containing {entries_to_log}")
+    def resolve(self: SelfContainsTheEntry) -> Matcher[Mapping]:
+        """Produce the Matcher to make the assertion."""
+        return has_entries(**self.entries)
 
     # Keyword argument form
     @overload
-    def __init__(self, **keys_valuematchers: V) -> None:
+    def __init__(self: SelfContainsTheEntry, **kv_args: V) -> None:
         ...
 
-    # Key to matcher dict form
+    # Key to value dict form
     @overload
-    def __init__(self, keys_valuematchers: Mapping[K, V]) -> None:
+    def __init__(self: SelfContainsTheEntry, kv_args: Mapping[K, V]) -> None:
         ...
 
-    # Alternating key/matcher form
+    # Alternating key/value form
     @overload
-    def __init__(self, *keys_valuematchers: Any) -> None:
+    def __init__(self: SelfContainsTheEntry, *kv_args: Any) -> None:
         ...
 
-    def __init__(self, *keys_valuematchers: Any, **kv_args: Any) -> None:
-        super().__init__(*keys_valuematchers, **kv_args)
+    def __init__(self: SelfContainsTheEntry, *kv_args: Any, **kv_kwargs: Any) -> None:
+        if not kv_args and not kv_kwargs:
+            msg = f"{self.__class__.__name__} must be given at least one argument."
+            raise UnableToFormResolution(msg)
+
+        if len(kv_args) > 1 and len(kv_args) % 2 == 1:
+            msg = f"{self.__class__.__name__} could not pair {kv_args}."
+            msg += " Make sure they're paired up properly!"
+            raise UnableToFormResolution(msg)
+
+        if len(kv_args) == 1:
+            # given a dictionary
+            self.entries = dict(kv_args[0]) | kv_kwargs
+        else:
+            try:
+                # given pairs, keywords, or both
+                self.entries = dict(kv_args) | kv_kwargs
+            except ValueError:
+                # given a list of implicitly paired arguments
+                pairs: Iterable[Tuple[Any, Any]] = [
+                    kv_args[i : i + 2]  # type: ignore
+                    for i in range(0, len(kv_args), 2)
+                ]
+                self.entries = dict(pairs) | kv_kwargs
+        self.entries_to_log = ", ".join(
+            f"{{{k}: {v}}}" for k, v in self.entries.items()
+        )

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -60,17 +60,17 @@ class ContainsTheEntry(BaseResolution):
 
         if len(kv_args) == 1:
             # given a dictionary
-            self.entries = dict(kv_args[0]) | kv_kwargs
+            self.entries = dict(kv_args[0], **kv_kwargs)
         else:
             try:
                 # given pairs, keywords, or both
-                self.entries = dict(kv_args) | kv_kwargs
+                self.entries = dict(kv_args, **kv_kwargs)
             except ValueError:
                 # given a list of implicitly paired arguments
                 pairs: Iterable[Tuple[Any, Any]] = [
                     (kv_args[i], kv_args[i + 1]) for i in range(0, len(kv_args), 2)
                 ]
-                self.entries = dict(pairs) | kv_kwargs
+                self.entries = dict(pairs, **kv_kwargs)
         self.entries_to_log = ", ".join(
             f"{{{k}: {v}}}" for k, v in self.entries.items()
         )

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -73,8 +73,7 @@ class ContainsTheEntry(BaseResolution):
             except ValueError:
                 # given a list of implicitly paired arguments
                 pairs: Iterable[Tuple[Any, Any]] = [
-                    kv_args[i : i + 2]  # type: ignore
-                    for i in range(0, len(kv_args), 2)
+                    (kv_args[i], kv_args[i + 1]) for i in range(0, len(kv_args), 2)
                 ]
                 self.entries = dict(pairs) | kv_kwargs
         self.entries_to_log = ", ".join(

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -30,10 +30,10 @@ class ContainsTheEntry(BaseResolution):
     """
 
     def describe(self: SelfContainsTheEntry) -> str:
-        """Describe the Resolution in the present tense."""
-        return f"Contain the entries {self.entries_to_log}."
+        """Describe the Resolution's expectation."""
+        return f"A mapping with the entries {self.entries_to_log}."
 
-    @beat("... hoping it's a dict containing {entries_to_log}")
+    @beat("... hoping it's a mapping with the entries {entries_to_log}")
     def resolve(self: SelfContainsTheEntry) -> Matcher[Mapping]:
         """Produce the Matcher to make the assertion."""
         return has_entries(**self.entries)
@@ -54,10 +54,6 @@ class ContainsTheEntry(BaseResolution):
         ...
 
     def __init__(self: SelfContainsTheEntry, *kv_args: Any, **kv_kwargs: Any) -> None:
-        if not kv_args and not kv_kwargs:
-            msg = f"{self.__class__.__name__} must be given at least one argument."
-            raise UnableToFormResolution(msg)
-
         if len(kv_args) > 1 and len(kv_args) % 2 == 1:
             msg = f"{self.__class__.__name__} could not pair {kv_args}."
             msg += " Make sure they're paired up properly!"

--- a/screenpy/resolutions/contains_the_item.py
+++ b/screenpy/resolutions/contains_the_item.py
@@ -24,10 +24,10 @@ class ContainsTheItem:
     """
 
     def describe(self: SelfContainsTheItem) -> str:
-        """Describe the Resolution in present tense."""
-        return f'Match a list containing "{self.item}".'
+        """Describe the Resolution's expectation."""
+        return f'A sequence containing "{self.item}".'
 
-    @beat('... hoping it\'s a list containing the item "{item}".')
+    @beat('... hoping it contains "{item}".')
     def resolve(self: SelfContainsTheItem) -> Matcher[Sequence[T]]:
         """Produce the Matcher to make the assertion."""
         return has_item(self.item)

--- a/screenpy/resolutions/contains_the_item.py
+++ b/screenpy/resolutions/contains_the_item.py
@@ -2,17 +2,18 @@
 Matches a list that contains the desired item.
 """
 
-from typing import TypeVar
+from typing import Sequence, TypeVar
 
 from hamcrest import has_item
-from hamcrest.library.collection.issequence_containing import IsSequenceContaining
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
 
+SelfContainsTheItem = TypeVar("SelfContainsTheItem", bound="ContainsTheItem")
 T = TypeVar("T")
 
 
-class ContainsTheItem(BaseResolution):
+class ContainsTheItem:
     """Match an iterable containing a specific item.
 
     Examples::
@@ -22,9 +23,14 @@ class ContainsTheItem(BaseResolution):
         )
     """
 
-    matcher: IsSequenceContaining
-    line = 'a list containing the item "{expectation}"'
-    matcher_function = has_item
+    def describe(self: SelfContainsTheItem) -> str:
+        """Describe the Resolution in present tense."""
+        return f'Match a list containing "{self.item}".'
 
-    def __init__(self, match: T) -> None:
-        super().__init__(match)
+    @beat('... hoping it\'s a list containing the item "{item}".')
+    def resolve(self: SelfContainsTheItem) -> Matcher[Sequence[T]]:
+        """Produce the Matcher to make the assertion."""
+        return has_item(self.item)
+
+    def __init__(self: SelfContainsTheItem, item: T) -> None:
+        self.item = item

--- a/screenpy/resolutions/contains_the_item.py
+++ b/screenpy/resolutions/contains_the_item.py
@@ -9,7 +9,6 @@ from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
 
-SelfContainsTheItem = TypeVar("SelfContainsTheItem", bound="ContainsTheItem")
 T = TypeVar("T")
 
 
@@ -23,14 +22,14 @@ class ContainsTheItem:
         )
     """
 
-    def describe(self: SelfContainsTheItem) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'A sequence containing "{self.item}".'
 
     @beat('... hoping it contains "{item}".')
-    def resolve(self: SelfContainsTheItem) -> Matcher[Sequence[T]]:
+    def resolve(self) -> Matcher[Sequence[T]]:
         """Produce the Matcher to make the assertion."""
         return has_item(self.item)
 
-    def __init__(self: SelfContainsTheItem, item: T) -> None:
+    def __init__(self, item: T) -> None:
         self.item = item

--- a/screenpy/resolutions/contains_the_key.py
+++ b/screenpy/resolutions/contains_the_key.py
@@ -9,7 +9,6 @@ from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
 
-SelfContainsTheKey = TypeVar("SelfContainsTheKey", bound="ContainsTheKey")
 K = TypeVar("K", bound=Hashable)
 
 
@@ -21,12 +20,12 @@ class ContainsTheKey(Generic[K]):
         the_actor.should(See.the(LastResponseBody(), ContainsTheKey("skeleton")))
     """
 
-    def describe(self: SelfContainsTheKey) -> str:
+    def describe(self) -> str:
         """Describe the Resolution in the present tense."""
         return f'Contain the key "{self.key}".'
 
     @beat('... hoping it\'s a dict containing the key "{key}".')
-    def resolve(self: SelfContainsTheKey) -> Matcher[Mapping[K, Any]]:
+    def resolve(self) -> Matcher[Mapping[K, Any]]:
         """Produce the Matcher to make the assertion."""
         return has_key(self.key)
 

--- a/screenpy/resolutions/contains_the_key.py
+++ b/screenpy/resolutions/contains_the_key.py
@@ -2,15 +2,18 @@
 Matches a dictionary that contains the desired key.
 """
 
-from typing import Hashable
+from typing import Any, Generic, Hashable, Mapping, TypeVar
 
 from hamcrest import has_key
-from hamcrest.library.collection.isdict_containingkey import IsDictContainingKey
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfContainsTheKey = TypeVar("SelfContainsTheKey", bound="ContainsTheKey")
+K = TypeVar("K", bound=Hashable)
 
 
-class ContainsTheKey(BaseResolution):
+class ContainsTheKey(Generic[K]):
     """Match a dictionary containing a specific key.
 
     Examples::
@@ -18,9 +21,14 @@ class ContainsTheKey(BaseResolution):
         the_actor.should(See.the(LastResponseBody(), ContainsTheKey("skeleton")))
     """
 
-    matcher: IsDictContainingKey
-    line = 'a dict containing the key "{expectation}"'
-    matcher_function = has_key
+    def describe(self: SelfContainsTheKey) -> str:
+        """Describe the Resolution in the present tense."""
+        return f'Contain the key "{self.key}".'
 
-    def __init__(self, key_match: Hashable) -> None:
-        super().__init__(key_match)
+    @beat('... hoping it\'s a dict containing the key "{key}".')
+    def resolve(self: SelfContainsTheKey) -> Matcher[Mapping[K, Any]]:
+        """Produce the Matcher to make the assertion."""
+        return has_key(self.key)
+
+    def __init__(self, key: K) -> None:
+        self.key = key

--- a/screenpy/resolutions/contains_the_text.py
+++ b/screenpy/resolutions/contains_the_text.py
@@ -2,13 +2,17 @@
 Matches a substring.
 """
 
+from typing import TypeVar
+
 from hamcrest import contains_string
-from hamcrest.library.text.stringcontains import StringContains
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfContainsTheText = TypeVar("SelfContainsTheText", bound="ContainsTheText")
 
 
-class ContainsTheText(BaseResolution):
+class ContainsTheText:
     """Match a specific substring of a string.
 
     Examples::
@@ -18,9 +22,14 @@ class ContainsTheText(BaseResolution):
         )
     """
 
-    matcher: StringContains
-    line = 'text containing "{expectation}"'
-    matcher_function = contains_string
+    def describe(self: SelfContainsTheText) -> str:
+        """Describe the Resolution in the present tense."""
+        return f'Contain the substring "{self.text}".'
 
-    def __init__(self, match: str) -> None:
-        super().__init__(match)
+    @beat('... hoping it\'s text containing "{text}".')
+    def resolve(self: SelfContainsTheText) -> Matcher[str]:
+        """Produce the Matcher to make the assertion."""
+        return contains_string(self.text)
+
+    def __init__(self: SelfContainsTheText, text: str) -> None:
+        self.text = text

--- a/screenpy/resolutions/contains_the_text.py
+++ b/screenpy/resolutions/contains_the_text.py
@@ -23,10 +23,10 @@ class ContainsTheText:
     """
 
     def describe(self: SelfContainsTheText) -> str:
-        """Describe the Resolution in the present tense."""
-        return f'Contain the substring "{self.text}".'
+        """Describe the Resolution's expectation."""
+        return f'Containing the text "{self.text}".'
 
-    @beat('... hoping it\'s text containing "{text}".')
+    @beat('... hoping it contains "{text}".')
     def resolve(self: SelfContainsTheText) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return contains_string(self.text)

--- a/screenpy/resolutions/contains_the_text.py
+++ b/screenpy/resolutions/contains_the_text.py
@@ -2,14 +2,10 @@
 Matches a substring.
 """
 
-from typing import TypeVar
-
 from hamcrest import contains_string
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfContainsTheText = TypeVar("SelfContainsTheText", bound="ContainsTheText")
 
 
 class ContainsTheText:
@@ -22,14 +18,14 @@ class ContainsTheText:
         )
     """
 
-    def describe(self: SelfContainsTheText) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'Containing the text "{self.text}".'
 
     @beat('... hoping it contains "{text}".')
-    def resolve(self: SelfContainsTheText) -> Matcher[str]:
+    def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return contains_string(self.text)
 
-    def __init__(self: SelfContainsTheText, text: str) -> None:
+    def __init__(self, text: str) -> None:
         self.text = text

--- a/screenpy/resolutions/contains_the_value.py
+++ b/screenpy/resolutions/contains_the_value.py
@@ -2,17 +2,18 @@
 Matches a dictionary that contains a specific value.
 """
 
-from typing import TypeVar
+from typing import Any, Generic, Mapping, TypeVar
 
 from hamcrest import has_value
-from hamcrest.library.collection.isdict_containingvalue import IsDictContainingValue
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
 
+SelfContainsTheValue = TypeVar("SelfContainsTheValue", bound="ContainsTheValue")
 V = TypeVar("V")
 
 
-class ContainsTheValue(BaseResolution):
+class ContainsTheValue(Generic[V]):
     """Match a dictionary containing a specific value.
 
     Examples::
@@ -22,9 +23,14 @@ class ContainsTheValue(BaseResolution):
         )
     """
 
-    matcher: IsDictContainingValue
-    line = 'a dict containing the value "{expectation}"'
-    matcher_function = has_value
+    def describe(self: SelfContainsTheValue) -> str:
+        """Describe the Resolution's expectation."""
+        return f'Containing the value "{self.value}".'
+
+    @beat('... hoping it contains the value "{value}".')
+    def resolve(self: SelfContainsTheValue) -> Matcher[Mapping[Any, V]]:
+        """Produce the Matcher to form the assertion."""
+        return has_value(self.value)
 
     def __init__(self, value: V) -> None:
-        super().__init__(value)
+        self.value = value

--- a/screenpy/resolutions/contains_the_value.py
+++ b/screenpy/resolutions/contains_the_value.py
@@ -9,7 +9,6 @@ from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
 
-SelfContainsTheValue = TypeVar("SelfContainsTheValue", bound="ContainsTheValue")
 V = TypeVar("V")
 
 
@@ -23,12 +22,12 @@ class ContainsTheValue(Generic[V]):
         )
     """
 
-    def describe(self: SelfContainsTheValue) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'Containing the value "{self.value}".'
 
     @beat('... hoping it contains the value "{value}".')
-    def resolve(self: SelfContainsTheValue) -> Matcher[Mapping[Any, V]]:
+    def resolve(self) -> Matcher[Mapping[Any, V]]:
         """Produce the Matcher to form the assertion."""
         return has_value(self.value)
 

--- a/screenpy/resolutions/custom_matchers/is_in_bounds.py
+++ b/screenpy/resolutions/custom_matchers/is_in_bounds.py
@@ -12,25 +12,25 @@ from typing import Callable, Union
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
 
-InequalityFunc = Callable[[Union[int, float], Union[int, float]], bool]
+InequalityFunc = Callable[[float, float], bool]
 
 
-class IsInBounds(BaseMatcher[int]):
+class IsInBounds(BaseMatcher[float]):
     """Matches a number which is in the given range."""
 
     def __init__(
         self,
-        minorant: Union[int, float],
+        minorant: float,
         lower_comparator: InequalityFunc,
         upper_comparator: InequalityFunc,
-        majorant: Union[int, float],
+        majorant: float,
     ) -> None:
         self.minorant = minorant
         self.lower_comparator = lower_comparator
         self.upper_comparator = upper_comparator
         self.majorant = majorant
 
-    def _matches(self, item: Union[int, float]) -> bool:
+    def _matches(self, item: float) -> bool:
         matches_lower = self.lower_comparator(self.minorant, item)
         matches_upper = self.upper_comparator(item, self.majorant)
         return matches_lower and matches_upper
@@ -41,17 +41,13 @@ class IsInBounds(BaseMatcher[int]):
             f"the number is within the range of {self.minorant} and {self.majorant}"
         )
 
-    def describe_match(
-        self, item: Union[int, float], match_description: Description
-    ) -> None:
+    def describe_match(self, item: float, match_description: Description) -> None:
         """Describe the match."""
         match_description.append_text(
             f"{item} was within the range of {self.minorant} and {self.majorant}"
         )
 
-    def describe_mismatch(
-        self, item: Union[int, float], mismatch_description: Description
-    ) -> None:
+    def describe_mismatch(self, item: float, mismatch_description: Description) -> None:
         """Describe the failing case."""
         mismatch_description.append_text(
             f"{item} does not fall within the range of"

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -23,10 +23,10 @@ class EndsWith:
     """
 
     def describe(self: SelfEndsWith) -> str:
-        """Describe the Resolution in the present tense."""
+        """Describe the Resolution's expectation."""
         return f'Ending with {self.postfix}".'
 
-    @beat('... hoping it\'s text ending with "{postfix}".')
+    @beat('... hoping it ends with "{postfix}".')
     def resolve(self: SelfEndsWith) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return ends_with(self.postfix)

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -2,13 +2,17 @@
 Matches a string which ends with a substring.
 """
 
+from typing import TypeVar
+
 from hamcrest import ends_with
-from hamcrest.library.text.stringendswith import StringEndsWith
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfEndsWith = TypeVar("SelfEndsWith", bound="EndsWith")
 
 
-class EndsWith(BaseResolution):
+class EndsWith:
     """Match a string which ends with the given substring.
 
     Examples::
@@ -18,9 +22,14 @@ class EndsWith(BaseResolution):
         )
     """
 
-    matcher: StringEndsWith
-    line = 'text ending with "{expectation}".'
-    matcher_function = ends_with
+    def describe(self: SelfEndsWith) -> str:
+        """Describe the Resolution in the present tense."""
+        return f'Ending with {self.postfix}".'
 
-    def __init__(self, match: str) -> None:
-        super().__init__(match)
+    @beat('... hoping it\'s text ending with "{postfix}".')
+    def resolve(self: SelfEndsWith) -> Matcher[str]:
+        """Produce the Matcher to make the assertion."""
+        return ends_with(self.postfix)
+
+    def __init__(self, postfix: str) -> None:
+        self.postfix = postfix

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -2,14 +2,10 @@
 Matches a string which ends with a substring.
 """
 
-from typing import TypeVar
-
 from hamcrest import ends_with
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfEndsWith = TypeVar("SelfEndsWith", bound="EndsWith")
 
 
 class EndsWith:
@@ -22,12 +18,12 @@ class EndsWith:
         )
     """
 
-    def describe(self: SelfEndsWith) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'Ending with {self.postfix}".'
 
     @beat('... hoping it ends with "{postfix}".')
-    def resolve(self: SelfEndsWith) -> Matcher[str]:
+    def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return ends_with(self.postfix)
 

--- a/screenpy/resolutions/has_length.py
+++ b/screenpy/resolutions/has_length.py
@@ -23,8 +23,8 @@ class HasLength:
     """
 
     def describe(self: SelfHasLength) -> str:
-        """Describe the Resolution in the present tense."""
-        return f"Has {self.length} item{self.plural}."
+        """Describe the Resolution's expectation."""
+        return f"{self.length} item{self.plural} long."
 
     @beat("... hoping it's a collection with {length} item{plural} in it.")
     def resolve(self: SelfHasLength) -> Matcher[Sized]:

--- a/screenpy/resolutions/has_length.py
+++ b/screenpy/resolutions/has_length.py
@@ -2,13 +2,17 @@
 Matches the length of a collection.
 """
 
+from typing import Sized, TypeVar
+
 from hamcrest import has_length
-from hamcrest.library.object.haslength import HasLength as _HasLength
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfHasLength = TypeVar("SelfHasLength", bound="HasLength")
 
 
-class HasLength(BaseResolution):
+class HasLength:
     """Match against a collection with a specific length.
 
     Examples::
@@ -18,9 +22,15 @@ class HasLength(BaseResolution):
         )
     """
 
-    matcher: _HasLength
-    line = "a collection with {expectation} items in it"
-    matcher_function = has_length
+    def describe(self: SelfHasLength) -> str:
+        """Describe the Resolution in the present tense."""
+        return f"Has {self.length} item{self.plural}."
 
-    def __init__(self, match: int) -> None:
-        super().__init__(match)
+    @beat("... hoping it's a collection with {length} item{plural} in it.")
+    def resolve(self: SelfHasLength) -> Matcher[Sized]:
+        """Produce the Matcher to make the assertion."""
+        return has_length(self.length)
+
+    def __init__(self: SelfHasLength, length: int) -> None:
+        self.length = length
+        self.plural = "s" if self.length != 1 else ""

--- a/screenpy/resolutions/has_length.py
+++ b/screenpy/resolutions/has_length.py
@@ -2,14 +2,12 @@
 Matches the length of a collection.
 """
 
-from typing import Sized, TypeVar
+from typing import Sized
 
 from hamcrest import has_length
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfHasLength = TypeVar("SelfHasLength", bound="HasLength")
 
 
 class HasLength:
@@ -22,15 +20,15 @@ class HasLength:
         )
     """
 
-    def describe(self: SelfHasLength) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"{self.length} item{self.plural} long."
 
     @beat("... hoping it's a collection with {length} item{plural} in it.")
-    def resolve(self: SelfHasLength) -> Matcher[Sized]:
+    def resolve(self) -> Matcher[Sized]:
         """Produce the Matcher to make the assertion."""
         return has_length(self.length)
 
-    def __init__(self: SelfHasLength, length: int) -> None:
+    def __init__(self, length: int) -> None:
         self.length = length
         self.plural = "s" if self.length != 1 else ""

--- a/screenpy/resolutions/is_close_to.py
+++ b/screenpy/resolutions/is_close_to.py
@@ -23,7 +23,7 @@ class IsCloseTo:
     """
 
     def describe(self: SelfIsCloseTo) -> str:
-        """Describe the Resolution in present tense."""
+        """Describe the Resolution's expectation."""
         return f"At most {self.delta} away from {self.num}."
 
     @beat("... hoping it's at most {delta} away from {num}.")

--- a/screenpy/resolutions/is_close_to.py
+++ b/screenpy/resolutions/is_close_to.py
@@ -2,13 +2,17 @@
 Matches a value that falls within the range specified by the given delta.
 """
 
+from typing import TypeVar
+
 from hamcrest import close_to
-from hamcrest.library.number.iscloseto import IsCloseTo as _IsCloseTo
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfIsCloseTo = TypeVar("SelfIsCloseTo", bound="IsCloseTo")
 
 
-class IsCloseTo(BaseResolution):
+class IsCloseTo:
     """Matches a value that falls within the range specified by the given delta.
 
     Examples::
@@ -18,13 +22,15 @@ class IsCloseTo(BaseResolution):
         )
     """
 
-    matcher: _IsCloseTo
-    matcher_function = close_to
+    def describe(self: SelfIsCloseTo) -> str:
+        """Describe the Resolution in present tense."""
+        return f"At most {self.delta} away from {self.num}."
 
-    def get_line(self) -> str:
-        """Get the line that describes this Resolution."""
-        args, kwargs = self.expected
-        return f"a value at most {kwargs['delta']} away from {args[0]}."
+    @beat("... hoping it's at most {delta} away from {num}.")
+    def resolve(self: SelfIsCloseTo) -> Matcher[float]:
+        """Produce the Matcher to make the assertion."""
+        return close_to(self.num, self.delta)
 
     def __init__(self, num: int, delta: int = 1) -> None:
-        super().__init__(num, delta=delta)
+        self.num = num
+        self.delta = delta

--- a/screenpy/resolutions/is_close_to.py
+++ b/screenpy/resolutions/is_close_to.py
@@ -2,14 +2,10 @@
 Matches a value that falls within the range specified by the given delta.
 """
 
-from typing import TypeVar
-
 from hamcrest import close_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsCloseTo = TypeVar("SelfIsCloseTo", bound="IsCloseTo")
 
 
 class IsCloseTo:
@@ -22,12 +18,12 @@ class IsCloseTo:
         )
     """
 
-    def describe(self: SelfIsCloseTo) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"At most {self.delta} away from {self.num}."
 
     @beat("... hoping it's at most {delta} away from {num}.")
-    def resolve(self: SelfIsCloseTo) -> Matcher[float]:
+    def resolve(self) -> Matcher[float]:
         """Produce the Matcher to make the assertion."""
         return close_to(self.num, self.delta)
 

--- a/screenpy/resolutions/is_empty.py
+++ b/screenpy/resolutions/is_empty.py
@@ -2,13 +2,17 @@
 Matches an empty collection.
 """
 
+from typing import Sized, TypeVar
+
 from hamcrest import empty
-from hamcrest.library.collection.is_empty import IsEmpty as _IsEmpty
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfIsEmpty = TypeVar("SelfIsEmpty", bound="IsEmpty")
 
 
-class IsEmpty(BaseResolution):
+class IsEmpty:
     """Match on an empty collection.
 
     Examples::
@@ -16,9 +20,11 @@ class IsEmpty(BaseResolution):
         the_actor.should(See.the(List.of_all(VIDEO_FRAMES), IsEmpty()))
     """
 
-    matcher: _IsEmpty
-    line = "an empty collection"
-    matcher_function = empty
+    def describe(self: SelfIsEmpty) -> str:
+        """Describe the Resolution's expectation."""
+        return "An empty collection."
 
-    def __init__(self) -> None:
-        super().__init__()
+    @beat("... hoping it's an empty collection.")
+    def resolve(self: SelfIsEmpty) -> Matcher[Sized]:
+        """Produce the Matcher to make the assertion."""
+        return empty()

--- a/screenpy/resolutions/is_empty.py
+++ b/screenpy/resolutions/is_empty.py
@@ -2,14 +2,12 @@
 Matches an empty collection.
 """
 
-from typing import Sized, TypeVar
+from typing import Sized
 
 from hamcrest import empty
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsEmpty = TypeVar("SelfIsEmpty", bound="IsEmpty")
 
 
 class IsEmpty:
@@ -20,11 +18,11 @@ class IsEmpty:
         the_actor.should(See.the(List.of_all(VIDEO_FRAMES), IsEmpty()))
     """
 
-    def describe(self: SelfIsEmpty) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return "An empty collection."
 
     @beat("... hoping it's an empty collection.")
-    def resolve(self: SelfIsEmpty) -> Matcher[Sized]:
+    def resolve(self) -> Matcher[Sized]:
         """Produce the Matcher to make the assertion."""
         return empty()

--- a/screenpy/resolutions/is_equal_to.py
+++ b/screenpy/resolutions/is_equal_to.py
@@ -2,14 +2,12 @@
 Matches using equality.
 """
 
-from typing import Any, TypeVar
+from typing import Any
 
 from hamcrest import equal_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsEqualTo = TypeVar("SelfIsEqualTo", bound="IsEqualTo")
 
 
 class IsEqualTo:
@@ -27,9 +25,9 @@ class IsEqualTo:
         return f"Equal to {self.expected}."
 
     @beat("... hoping it's equal to {expected}.")
-    def resolve(self: SelfIsEqualTo) -> Matcher[Any]:
+    def resolve(self) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""
         return equal_to(self.expected)
 
-    def __init__(self: SelfIsEqualTo, obj: Any) -> None:
+    def __init__(self, obj: Any) -> None:
         self.expected = obj

--- a/screenpy/resolutions/is_equal_to.py
+++ b/screenpy/resolutions/is_equal_to.py
@@ -23,7 +23,7 @@ class IsEqualTo:
     """
 
     def describe(self) -> str:
-        """Describe the Resolution in present tense."""
+        """Describe the Resolution's expectation."""
         return f"Equal to {self.expected}."
 
     @beat("... hoping it's equal to {expected}.")

--- a/screenpy/resolutions/is_equal_to.py
+++ b/screenpy/resolutions/is_equal_to.py
@@ -2,17 +2,17 @@
 Matches using equality.
 """
 
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from hamcrest import equal_to
-from hamcrest.core.core.isequal import IsEqual
+from hamcrest.core.base_matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
 
-T = TypeVar("T")
+SelfIsEqualTo = TypeVar("SelfIsEqualTo", bound="IsEqualTo")
 
 
-class IsEqualTo(BaseResolution):
+class IsEqualTo:
     """Match on an equal object.
 
     Examples::
@@ -22,9 +22,10 @@ class IsEqualTo(BaseResolution):
         )
     """
 
-    matcher: IsEqual
-    line = "equal to {expectation}"
-    matcher_function = equal_to
+    @beat("... hoping it's equal to {expected}.")
+    def resolve(self: SelfIsEqualTo) -> Matcher[Any]:
+        """Produce the Matcher to make the assertion."""
+        return equal_to(self.expected)
 
-    def __init__(self, obj: T) -> None:
-        super().__init__(obj)
+    def __init__(self: SelfIsEqualTo, obj: Any) -> None:
+        self.expected = obj

--- a/screenpy/resolutions/is_equal_to.py
+++ b/screenpy/resolutions/is_equal_to.py
@@ -5,7 +5,7 @@ Matches using equality.
 from typing import Any, TypeVar
 
 from hamcrest import equal_to
-from hamcrest.core.base_matcher import Matcher
+from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
 

--- a/screenpy/resolutions/is_equal_to.py
+++ b/screenpy/resolutions/is_equal_to.py
@@ -22,6 +22,10 @@ class IsEqualTo:
         )
     """
 
+    def describe(self) -> str:
+        """Describe the Resolution in present tense."""
+        return f"Equal to {self.expected}."
+
     @beat("... hoping it's equal to {expected}.")
     def resolve(self: SelfIsEqualTo) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""

--- a/screenpy/resolutions/is_greater_than.py
+++ b/screenpy/resolutions/is_greater_than.py
@@ -2,15 +2,17 @@
 Matches a value greater than the given number.
 """
 
-from typing import Union
+from typing import Any, TypeVar
 
 from hamcrest import greater_than
-from hamcrest.library.number.ordering_comparison import OrderingComparison
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfIsGreaterThan = TypeVar("SelfIsGreaterThan", bound="IsGreaterThan")
 
 
-class IsGreaterThan(BaseResolution):
+class IsGreaterThan:
     """Match on a number that is greater than the given number.
 
     Examples::
@@ -18,9 +20,14 @@ class IsGreaterThan(BaseResolution):
         the_actor.should(See.the(Number.of(COUPONS), IsGreaterThan(1)))
     """
 
-    matcher: OrderingComparison
-    line = "greater than {expectation}"
-    matcher_function = greater_than
+    def describe(self: SelfIsGreaterThan) -> str:
+        """Describe the Resolution's expectation."""
+        return f"Greater than {self.number}."
 
-    def __init__(self, number: Union[int, float]) -> None:
-        super().__init__(number)
+    @beat("... hoping it's greater than {number}.")
+    def resolve(self: SelfIsGreaterThan) -> Matcher[Any]:
+        """Produce the Matcher to make the assertion."""
+        return greater_than(self.number)
+
+    def __init__(self, number: float) -> None:
+        self.number = number

--- a/screenpy/resolutions/is_greater_than.py
+++ b/screenpy/resolutions/is_greater_than.py
@@ -2,14 +2,12 @@
 Matches a value greater than the given number.
 """
 
-from typing import Any, TypeVar
+from typing import Any
 
 from hamcrest import greater_than
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsGreaterThan = TypeVar("SelfIsGreaterThan", bound="IsGreaterThan")
 
 
 class IsGreaterThan:
@@ -20,12 +18,12 @@ class IsGreaterThan:
         the_actor.should(See.the(Number.of(COUPONS), IsGreaterThan(1)))
     """
 
-    def describe(self: SelfIsGreaterThan) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"Greater than {self.number}."
 
     @beat("... hoping it's greater than {number}.")
-    def resolve(self: SelfIsGreaterThan) -> Matcher[Any]:
+    def resolve(self) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""
         return greater_than(self.number)
 

--- a/screenpy/resolutions/is_greater_than_or_equal_to.py
+++ b/screenpy/resolutions/is_greater_than_or_equal_to.py
@@ -2,15 +2,19 @@
 Matches a value greater than the given number.
 """
 
-from typing import Union
+from typing import Any, TypeVar
 
 from hamcrest import greater_than_or_equal_to
-from hamcrest.library.number.ordering_comparison import OrderingComparison
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfIsGreaterThanOrEqualTo = TypeVar(
+    "SelfIsGreaterThanOrEqualTo", bound="IsGreaterThanOrEqualTo"
+)
 
 
-class IsGreaterThanOrEqualTo(BaseResolution):
+class IsGreaterThanOrEqualTo:
     """Match on a number that is greater than or equal to the given number.
 
     Examples::
@@ -20,9 +24,14 @@ class IsGreaterThanOrEqualTo(BaseResolution):
         )
     """
 
-    matcher: OrderingComparison
-    line = "greater than or equal to {expectation}"
-    matcher_function = greater_than_or_equal_to
+    def describe(self: SelfIsGreaterThanOrEqualTo) -> str:
+        """Describe the Resolution's expectation."""
+        return f"Greater than or equal to {self.number}."
 
-    def __init__(self, number: Union[int, float]) -> None:
-        super().__init__(number)
+    @beat("... hoping it's greater than or equal to {number}.")
+    def resolve(self: SelfIsGreaterThanOrEqualTo) -> Matcher[Any]:
+        """Produce the Matcher to make the assertion."""
+        return greater_than_or_equal_to(self.number)
+
+    def __init__(self, number: float) -> None:
+        self.number = number

--- a/screenpy/resolutions/is_greater_than_or_equal_to.py
+++ b/screenpy/resolutions/is_greater_than_or_equal_to.py
@@ -2,16 +2,12 @@
 Matches a value greater than the given number.
 """
 
-from typing import Any, TypeVar
+from typing import Any
 
 from hamcrest import greater_than_or_equal_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsGreaterThanOrEqualTo = TypeVar(
-    "SelfIsGreaterThanOrEqualTo", bound="IsGreaterThanOrEqualTo"
-)
 
 
 class IsGreaterThanOrEqualTo:
@@ -24,12 +20,12 @@ class IsGreaterThanOrEqualTo:
         )
     """
 
-    def describe(self: SelfIsGreaterThanOrEqualTo) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"Greater than or equal to {self.number}."
 
     @beat("... hoping it's greater than or equal to {number}.")
-    def resolve(self: SelfIsGreaterThanOrEqualTo) -> Matcher[Any]:
+    def resolve(self) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""
         return greater_than_or_equal_to(self.number)
 

--- a/screenpy/resolutions/is_in_range.py
+++ b/screenpy/resolutions/is_in_range.py
@@ -45,7 +45,7 @@ class IsInRange:
     def __init__(self, *bounds: Union[int, str]) -> None:
         if len(bounds) > 2:
             msg = f"{self.__class__.__name__} was given too many arguments: {bounds}."
-            UnableToFormResolution(msg)
+            raise UnableToFormResolution(msg)
 
         self.bounds = bounds
         self.bounding_string = self.bounds[0]  # given bounding string

--- a/screenpy/resolutions/is_in_range.py
+++ b/screenpy/resolutions/is_in_range.py
@@ -2,7 +2,7 @@
 Matches a number against a range.
 """
 
-from typing import TypeVar, Union
+from typing import Union
 
 from hamcrest.core.matcher import Matcher
 
@@ -10,8 +10,6 @@ from screenpy.exceptions import UnableToFormResolution
 from screenpy.pacing import beat
 
 from .custom_matchers.is_in_bounds import is_in_bounds
-
-SelfIsInRange = TypeVar("SelfIsInRange", bound="IsInRange")
 
 
 class IsInRange:
@@ -35,12 +33,12 @@ class IsInRange:
         the_actor.should(See.the(Number.of(COOKIES), IsInRange("[1, 5)")))
     """
 
-    def describe(self: SelfIsInRange) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"In the range {self.bounding_string}."
 
     @beat("... hoping it's in the range {bounding_string}.")
-    def resolve(self: SelfIsInRange) -> Matcher[float]:
+    def resolve(self) -> Matcher[float]:
         """Produce the Matcher to make the assertion."""
         return is_in_bounds(*self.bounds)
 

--- a/screenpy/resolutions/is_less_than.py
+++ b/screenpy/resolutions/is_less_than.py
@@ -2,15 +2,17 @@
 Matches a value less than the given number.
 """
 
-from typing import Union
+from typing import TypeVar
 
 from hamcrest import less_than
-from hamcrest.library.number.ordering_comparison import OrderingComparison
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfIsLessThan = TypeVar("SelfIsLessThan", bound="IsLessThan")
 
 
-class IsLessThan(BaseResolution):
+class IsLessThan:
     """Match on a number that is less than the given number.
 
     Examples::
@@ -20,9 +22,14 @@ class IsLessThan(BaseResolution):
         )
     """
 
-    matcher: OrderingComparison
-    line = "less than {expectation}"
-    matcher_function = less_than
+    def describe(self: SelfIsLessThan) -> str:
+        """Describe the Resolution's expectation."""
+        return f"Less than {self.number}."
 
-    def __init__(self, number: Union[int, float]) -> None:
-        super().__init__(number)
+    @beat("... hoping it's less than {number}.")
+    def resolve(self: SelfIsLessThan) -> Matcher[float]:
+        """Produce the Matcher to make the assertion."""
+        return less_than(self.number)
+
+    def __init__(self, number: float) -> None:
+        self.number = number

--- a/screenpy/resolutions/is_less_than.py
+++ b/screenpy/resolutions/is_less_than.py
@@ -2,14 +2,10 @@
 Matches a value less than the given number.
 """
 
-from typing import TypeVar
-
 from hamcrest import less_than
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsLessThan = TypeVar("SelfIsLessThan", bound="IsLessThan")
 
 
 class IsLessThan:
@@ -22,12 +18,12 @@ class IsLessThan:
         )
     """
 
-    def describe(self: SelfIsLessThan) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"Less than {self.number}."
 
     @beat("... hoping it's less than {number}.")
-    def resolve(self: SelfIsLessThan) -> Matcher[float]:
+    def resolve(self) -> Matcher[float]:
         """Produce the Matcher to make the assertion."""
         return less_than(self.number)
 

--- a/screenpy/resolutions/is_less_than_or_equal_to.py
+++ b/screenpy/resolutions/is_less_than_or_equal_to.py
@@ -2,15 +2,19 @@
 Matches a value less than or equal to the given number.
 """
 
-from typing import Union
+from typing import TypeVar
 
 from hamcrest import less_than_or_equal_to
-from hamcrest.library.number.ordering_comparison import OrderingComparison
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfIsLessThanOrEqualTo = TypeVar(
+    "SelfIsLessThanOrEqualTo", bound="IsLessThanOrEqualTo"
+)
 
 
-class IsLessThanOrEqualTo(BaseResolution):
+class IsLessThanOrEqualTo:
     """Match on a number that is less than or equal to the given number.
 
     Examples::
@@ -20,9 +24,14 @@ class IsLessThanOrEqualTo(BaseResolution):
         )
     """
 
-    matcher: OrderingComparison
-    line = "less than or equal to {expectation}"
-    matcher_function = less_than_or_equal_to
+    def describe(self: SelfIsLessThanOrEqualTo) -> str:
+        """Describe the Resolution's expectation."""
+        return f"Less than or equal to {self.number}."
 
-    def __init__(self, number: Union[int, float]) -> None:
-        super().__init__(number)
+    @beat("... hoping it's less than or equal to {number}.")
+    def resolve(self: SelfIsLessThanOrEqualTo) -> Matcher[float]:
+        """Produce the Matcher to make the assertion."""
+        return less_than_or_equal_to(self.number)
+
+    def __init__(self, number: float) -> None:
+        self.number = number

--- a/screenpy/resolutions/is_less_than_or_equal_to.py
+++ b/screenpy/resolutions/is_less_than_or_equal_to.py
@@ -2,16 +2,10 @@
 Matches a value less than or equal to the given number.
 """
 
-from typing import TypeVar
-
 from hamcrest import less_than_or_equal_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfIsLessThanOrEqualTo = TypeVar(
-    "SelfIsLessThanOrEqualTo", bound="IsLessThanOrEqualTo"
-)
 
 
 class IsLessThanOrEqualTo:
@@ -24,12 +18,12 @@ class IsLessThanOrEqualTo:
         )
     """
 
-    def describe(self: SelfIsLessThanOrEqualTo) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"Less than or equal to {self.number}."
 
     @beat("... hoping it's less than or equal to {number}.")
-    def resolve(self: SelfIsLessThanOrEqualTo) -> Matcher[float]:
+    def resolve(self) -> Matcher[float]:
         """Produce the Matcher to make the assertion."""
         return less_than_or_equal_to(self.number)
 

--- a/screenpy/resolutions/is_not.py
+++ b/screenpy/resolutions/is_not.py
@@ -11,7 +11,6 @@ from screenpy.pacing import beat
 from screenpy.protocols import Resolvable
 from screenpy.speech_tools import get_additive_description
 
-SelfIsNot = TypeVar("SelfIsNot", bound="IsNot")
 T = TypeVar("T")
 
 
@@ -23,12 +22,12 @@ class IsNot:
         the_actor.should(See.the(Element(WELCOME_BANNER), IsNot(Visible())))
     """
 
-    def describe(self: SelfIsNot) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f"Not {self.resolution_to_log}."
 
     @beat("... hoping it's not {resolution_to_log}.")
-    def resolve(self: SelfIsNot) -> Matcher[object]:
+    def resolve(self) -> Matcher[object]:
         """Produce the Matcher to make the assertion."""
         return is_not(self.resolution.resolve())
 

--- a/screenpy/resolutions/is_not.py
+++ b/screenpy/resolutions/is_not.py
@@ -2,17 +2,20 @@
 Matches the negation of another Resolution.
 """
 
-from typing import Type, TypeVar, Union
+from typing import TypeVar
 
 from hamcrest import is_not
-from hamcrest.core.core.isnot import IsNot as _IsNot
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+from screenpy.protocols import Resolvable
+from screenpy.speech_tools import get_additive_description
 
+SelfIsNot = TypeVar("SelfIsNot", bound="IsNot")
 T = TypeVar("T")
 
 
-class IsNot(BaseResolution):
+class IsNot:
     """Match a negated Resolution.
 
     Examples::
@@ -20,13 +23,15 @@ class IsNot(BaseResolution):
         the_actor.should(See.the(Element(WELCOME_BANNER), IsNot(Visible())))
     """
 
-    matcher: _IsNot
-    line = "not {expectation}"
-    matcher_function = is_not
+    def describe(self: SelfIsNot) -> str:
+        """Describe the Resolution's expectation."""
+        return f"Not {self.resolution_to_log}."
 
-    def get_line(self) -> str:
-        """Override base get_line to formulate this unique line."""
-        return self.line.format(expectation=self.expected.get_line())
+    @beat("... hoping it's not {resolution_to_log}.")
+    def resolve(self: SelfIsNot) -> Matcher[object]:
+        """Produce the Matcher to make the assertion."""
+        return is_not(self.resolution.resolve())
 
-    def __init__(self, match: Union[Type, T]) -> None:
-        super().__init__(match)
+    def __init__(self, resolution: Resolvable) -> None:
+        self.resolution = resolution
+        self.resolution_to_log = get_additive_description(self.resolution)

--- a/screenpy/resolutions/matches.py
+++ b/screenpy/resolutions/matches.py
@@ -2,13 +2,17 @@
 Matches a string using a regex pattern.
 """
 
+from typing import TypeVar
+
 from hamcrest import matches_regexp
-from hamcrest.library.text.stringmatches import StringMatchesPattern
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfMatches = TypeVar("SelfMatches", bound="Matches")
 
 
-class Matches(BaseResolution):
+class Matches:
     """Match a string using a regular expression.
 
     Examples::
@@ -19,9 +23,14 @@ class Matches(BaseResolution):
         )
     """
 
-    matcher: StringMatchesPattern
-    line = 'text matching the regular expression "{expectation}".'
-    matcher_function = matches_regexp
+    def describe(self: SelfMatches) -> str:
+        """Describe the Resolution's expectation."""
+        return f'Text matching the pattern r"{self.pattern}".'
 
-    def __init__(self, match: str) -> None:
-        super().__init__(match)
+    @beat('... hoping it\'s text matching the pattern r"{pattern}".')
+    def resolve(self: SelfMatches) -> Matcher[str]:
+        """Produce the Matcher to make the assertion."""
+        return matches_regexp(self.pattern)
+
+    def __init__(self, pattern: str) -> None:
+        self.pattern = pattern

--- a/screenpy/resolutions/matches.py
+++ b/screenpy/resolutions/matches.py
@@ -2,14 +2,10 @@
 Matches a string using a regex pattern.
 """
 
-from typing import TypeVar
-
 from hamcrest import matches_regexp
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfMatches = TypeVar("SelfMatches", bound="Matches")
 
 
 class Matches:
@@ -23,12 +19,12 @@ class Matches:
         )
     """
 
-    def describe(self: SelfMatches) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'Text matching the pattern r"{self.pattern}".'
 
     @beat('... hoping it\'s text matching the pattern r"{pattern}".')
-    def resolve(self: SelfMatches) -> Matcher[str]:
+    def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return matches_regexp(self.pattern)
 

--- a/screenpy/resolutions/reads_exactly.py
+++ b/screenpy/resolutions/reads_exactly.py
@@ -2,14 +2,10 @@
 ReadsExactly an exact string.
 """
 
-from typing import TypeVar
-
 from hamcrest import has_string
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfReadsExactly = TypeVar("SelfReadsExactly", bound="ReadsExactly")
 
 
 class ReadsExactly:
@@ -22,12 +18,12 @@ class ReadsExactly:
         )
     """
 
-    def describe(self: SelfReadsExactly) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'"{self.text}", verbatim.'
 
     @beat('... hoping it\'s "{text}", verbatim.')
-    def resolve(self: SelfReadsExactly) -> Matcher[object]:
+    def resolve(self) -> Matcher[object]:
         """Produce the Matcher to make the assertion."""
         return has_string(self.text)
 

--- a/screenpy/resolutions/reads_exactly.py
+++ b/screenpy/resolutions/reads_exactly.py
@@ -1,14 +1,18 @@
 """
-Matches an exact string.
+ReadsExactly an exact string.
 """
 
+from typing import TypeVar
+
 from hamcrest import has_string
-from hamcrest.library.object.hasstring import HasString
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfReadsExactly = TypeVar("SelfReadsExactly", bound="ReadsExactly")
 
 
-class ReadsExactly(BaseResolution):
+class ReadsExactly:
     """Match a specific string exactly.
 
     Examples::
@@ -18,9 +22,14 @@ class ReadsExactly(BaseResolution):
         )
     """
 
-    matcher: HasString
-    line = '"{expectation}", verbatim'
-    matcher_function = has_string
+    def describe(self: SelfReadsExactly) -> str:
+        """Describe the Resolution's expectation."""
+        return f'"{self.text}", verbatim.'
 
-    def __init__(self, match: str) -> None:
-        super().__init__(match)
+    @beat('... hoping it\'s "{text}", verbatim.')
+    def resolve(self: SelfReadsExactly) -> Matcher[object]:
+        """Produce the Matcher to make the assertion."""
+        return has_string(self.text)
+
+    def __init__(self, text: str) -> None:
+        self.text = text

--- a/screenpy/resolutions/starts_with.py
+++ b/screenpy/resolutions/starts_with.py
@@ -2,14 +2,10 @@
 Matches a string which begins with a substring.
 """
 
-from typing import TypeVar
-
 from hamcrest import starts_with
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-
-SelfStartsWith = TypeVar("SelfStartsWith", bound="StartsWith")
 
 
 class StartsWith:
@@ -22,12 +18,12 @@ class StartsWith:
         )
     """
 
-    def describe(self: SelfStartsWith) -> str:
+    def describe(self) -> str:
         """Describe the Resolution's expectation."""
         return f'Starting with "{self.prefix}".'
 
     @beat('... hoping it starts with "{prefix}".')
-    def resolve(self: SelfStartsWith) -> Matcher[str]:
+    def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return starts_with(self.prefix)
 

--- a/screenpy/resolutions/starts_with.py
+++ b/screenpy/resolutions/starts_with.py
@@ -2,13 +2,17 @@
 Matches a string which begins with a substring.
 """
 
+from typing import TypeVar
+
 from hamcrest import starts_with
-from hamcrest.library.text.stringstartswith import StringStartsWith
+from hamcrest.core.matcher import Matcher
 
-from .base_resolution import BaseResolution
+from screenpy.pacing import beat
+
+SelfStartsWith = TypeVar("SelfStartsWith", bound="StartsWith")
 
 
-class StartsWith(BaseResolution):
+class StartsWith:
     """Match a string which starts with the given substring.
 
     Examples::
@@ -18,9 +22,14 @@ class StartsWith(BaseResolution):
         )
     """
 
-    matcher: StringStartsWith
-    line = 'text starting with "{expectation}".'
-    matcher_function = starts_with
+    def describe(self: SelfStartsWith) -> str:
+        """Describe the Resolution's expectation."""
+        return f'Starting with "{self.prefix}".'
 
-    def __init__(self, match: str) -> None:
-        super().__init__(match)
+    @beat('... hoping it starts with "{prefix}".')
+    def resolve(self: SelfStartsWith) -> Matcher[str]:
+        """Produce the Matcher to make the assertion."""
+        return starts_with(self.prefix)
+
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix

--- a/screenpy/speech_tools.py
+++ b/screenpy/speech_tools.py
@@ -5,26 +5,28 @@ A grab-bag of useful language-massaging functions with broad applicability.
 import re
 from typing import Any, Union
 
-from screenpy.protocols import Answerable, Describable, Performable
+from screenpy.protocols import Answerable, Describable, Performable, Resolvable
 
 
-def get_additive_description(
-    describable: Union[Performable, Answerable, Describable, Any]
-) -> str:
+def get_additive_description(describable: Union[Describable, Any]) -> str:
     """Extract a description that can be placed within a sentence.
 
-    The ``describe`` method of Performables and Answerables will provide a
-    description in present tense, capitalized and with punctuation at the end.
-    Lower that case, remove that punctuation; bam! You can stick that in the
-    middle of a different sentence.
+    The ``describe`` method of Describables will provide a description,
+    capitalized and with punctuation at the end. Lower that case, remove that
+    punctuation; bam! You can stick that in the middle of a new sentence.
 
     If there is no ``describe`` method, try to create a description using the
-    class name by replacing each capital letter with a space and a lower-case
+    class name: replace each capital letter with a space and a lower-case
     letter (e.g. "BuildItAndTheyWillCome" -> "build it and they will come").
 
-    If the describable does not appear to be an Answerable or Performable,
-    stick a "the" in front of the class name. This should make it read like
-    "the list" or "the str".
+    If the object does not appear to be any -able, stick a "the" in front of
+    the class name. This should make it read like "the list" or "the str".
+
+    Args:
+        describable: the object to attempt to describe.
+
+    Returns:
+        str: the string to place within another string.
     """
     if isinstance(describable, Describable):
         description = describable.describe()  # type: ignore # see PEP 544
@@ -33,12 +35,12 @@ def get_additive_description(
             description = re.sub(r"[.,?!;:]*$", r"", description)
         else:
             description = "something indescribable"
-    elif isinstance(describable, (Answerable, Performable)):
+    elif isinstance(describable, (Answerable, Performable, Resolvable)):
         # No describe method, so fabricate a description from the class name.
         description = describable.__class__.__name__
         description = re.sub(r"(?<!^)([A-Z])", r" \1", description).lower()
     else:
-        # Neither describable nor Answerable/Performable, must be a value.
+        # Neither Describable nor any other -able, must be a value.
         description = f"the {describable.__class__.__name__}"
 
     return description

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -432,7 +432,7 @@ class TestSee:
         mock_question.describe.return_value = "What was your mother?"
         mock_question.caught_exception = ValueError("Failure msg")
         mock_resolution = FakeResolution()
-        mock_resolution.get_line.return_value = "A hamster!"
+        mock_resolution.describe.return_value = "A hamster!"
 
         See.the(mock_question, mock_resolution).perform_as(Tester)
 
@@ -447,7 +447,7 @@ class TestSee:
     def test_calls_assert_that_with_value(self, mocked_assert_that, Tester) -> None:
         test_value = "Your father smelt of"
         mock_resolution = FakeResolution()
-        mock_resolution.get_line.return_value = "Elderberries!"
+        mock_resolution.describe.return_value = "Elderberries!"
 
         See.the(test_value, mock_resolution).perform_as(Tester)
 
@@ -457,11 +457,11 @@ class TestSee:
         mock_question = FakeQuestion()
         mock_question.describe.return_value = "Can you speak?"
         mock_resolution = FakeResolution()
-        mock_resolution.get_line.return_value = "I speak"
+        mock_resolution.describe.return_value = "Only this sentence."
 
         assert (
             See(mock_question, mock_resolution).describe()
-            == "See if can you speak is I speak."
+            == "See if can you speak is only this sentence."
         )
 
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -13,6 +13,7 @@ from screenpy.resolutions import (
     DoesNot,
     EndsWith,
     Equal,
+    EqualTo,
     HasLength,
     IsCloseTo,
     IsEmpty,
@@ -382,7 +383,7 @@ class TestIsLessThanOrEqualTo:
 
 class TestIsNot:
     def test_can_be_instantiated(self) -> None:
-        in_ = IsNot(IsEqualTo(True))
+        in_ = IsNot(EqualTo(True))
 
         assert isinstance(in_, IsNot)
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -31,6 +31,17 @@ from screenpy.resolutions.base_resolution import BaseMatcher
 
 
 class TestBaseResolution:
+    def test_subclasses_deprecated(self):
+
+        class MockResolution(BaseResolution):
+            """Must be defined here for new mock matchers."""
+
+            matcher_function = mock.create_autospec(BaseMatcher)
+
+        with pytest.deprecated_call():
+            MockResolution()
+
+    @pytest.mark.filterwarnings("ignore:BaseResolution")
     @pytest.mark.parametrize(
         "args,kwargs,expected",
         [
@@ -54,6 +65,7 @@ class TestBaseResolution:
         assert resolution.expected == expected
         resolution.matcher_function.assert_called_once_with(*args, **kwargs)
 
+    @pytest.mark.filterwarnings("ignore:BaseResolution")
     @pytest.mark.parametrize(
         "method,args,expected_method",
         [
@@ -87,6 +99,7 @@ class TestBaseResolution:
 
         getattr(resolution.matcher, expected_method).assert_called_once_with(*args)
 
+    @pytest.mark.filterwarnings("ignore:BaseResolution")
     def test___repr__(self) -> None:
         class MockResolution(BaseResolution):
             """Must be defined here for new mock matchers."""

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -30,10 +30,6 @@ from screenpy.resolutions import (
 from screenpy.resolutions.base_resolution import BaseMatcher
 
 
-def assert_matcher_annotation(obj: BaseResolution) -> None:
-    assert type(obj.matcher) is obj.__annotations__["matcher"]
-
-
 class TestBaseResolution:
     @pytest.mark.parametrize(
         "args,kwargs,expected",
@@ -112,13 +108,10 @@ class TestContainsItemMatching:
         assert isinstance(cim, ContainsItemMatching)
 
     def test_the_test(self) -> None:
-        cim = ContainsItemMatching(r"([Ss]pam ?)+")
+        cim = ContainsItemMatching(r"([Ss]pam ?)+").resolve()
 
         assert cim.matches(["Spam", "Eggs", "Spam and eggs"])
         assert not cim.matches(["Porridge"])
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ContainsItemMatching(r"^$"))
 
 
 class TestContainsTheEntry:
@@ -131,10 +124,10 @@ class TestContainsTheEntry:
 
     def test_the_test(self) -> None:
         """Matches dictionaries containing the entry(/ies)"""
-        cte_single = ContainsTheEntry(key="value")
-        cte_multiple = ContainsTheEntry(key1="value1", key2="value2")
-        cte_alt2 = ContainsTheEntry({"key2": "something2"})
-        cte_alt3 = ContainsTheEntry("key3", "something3")
+        cte_single = ContainsTheEntry(key="value").resolve()
+        cte_multiple = ContainsTheEntry(key1="value1", key2="value2").resolve()
+        cte_alt2 = ContainsTheEntry({"key2": "something2"}).resolve()
+        cte_alt3 = ContainsTheEntry("key3", "something3").resolve()
 
         assert cte_alt2.matches({"key2": "something2"})
         assert cte_alt3.matches({"key3": "something3"})
@@ -147,9 +140,6 @@ class TestContainsTheEntry:
         )
         assert not cte_multiple.matches({"key1": "value1"})
 
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ContainsTheEntry(key2="hi"))
-
 
 class TestContainsTheItem:
     def test_can_be_instantiated(self) -> None:
@@ -159,13 +149,10 @@ class TestContainsTheItem:
 
     def test_the_test(self) -> None:
         """Matches lists containing the item"""
-        cti = ContainsTheItem(1)
+        cti = ContainsTheItem(1).resolve()
 
         assert cti.matches(range(0, 10))
         assert not cti.matches({0, 3, 5})
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ContainsTheItem(1))
 
 
 class TestContainsTheKey:
@@ -176,14 +163,11 @@ class TestContainsTheKey:
 
     def test_the_test(self) -> None:
         """Matches dictionaries containing the key"""
-        ctk = ContainsTheKey("key")
+        ctk = ContainsTheKey("key").resolve()
 
         assert ctk.matches({"key": "value"})
         assert ctk.matches({"key": "value", "play": "Hamlet"})
         assert not ctk.matches({"play": "Hamlet"})
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ContainsTheKey(1))
 
 
 class TestContainsTheText:
@@ -194,13 +178,10 @@ class TestContainsTheText:
 
     def test_the_test(self) -> None:
         """Matches text with the substring"""
-        ctt = ContainsTheText("hello")
+        ctt = ContainsTheText("hello").resolve()
 
         assert ctt.matches("hello world!")
         assert not ctt.matches("goodbye universe.")
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ContainsTheText("hello"))
 
 
 class TestContainsTheValue:
@@ -211,14 +192,11 @@ class TestContainsTheValue:
 
     def test_the_test(self) -> None:
         """Matches dictionaries which contain the value"""
-        ctv = ContainsTheValue("value")
+        ctv = ContainsTheValue("value").resolve()
 
         assert ctv.matches({"key": "value"})
         assert ctv.matches({"key": "value", "play": "Hamlet"})
         assert not ctv.matches({"play": "Hamlet"})
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ContainsTheValue(1))
 
 
 class TestEmpty:
@@ -229,13 +207,10 @@ class TestEmpty:
 
     def test_the_test(self) -> None:
         """Matches against empty collections"""
-        e = IsEmpty()
+        e = IsEmpty().resolve()
 
         assert e.matches([])
         assert not e.matches(["not", "empty"])
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsEmpty())
 
 
 class TestEndsWith:
@@ -245,13 +220,10 @@ class TestEndsWith:
         assert isinstance(ew, EndsWith)
 
     def test_the_test(self) -> None:
-        ew = EndsWith("of life!")
+        ew = EndsWith("of life!").resolve()
 
         assert ew.matches("Bereft of life!")
         assert not ew.matches("He has ceased to be!")
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(EndsWith(""))
 
 
 class TestHasLength:
@@ -262,13 +234,10 @@ class TestHasLength:
 
     def test_the_test(self) -> None:
         """Matches lists with the right length"""
-        hl = HasLength(5)
+        hl = HasLength(5).resolve()
 
         assert hl.matches([1, 2, 3, 4, 5])
         assert not hl.matches([1])
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(HasLength(1))
 
 
 class TestIsCloseTo:
@@ -278,23 +247,12 @@ class TestIsCloseTo:
         assert isinstance(ict, IsCloseTo)
 
     def test_the_test(self) -> None:
-        ict = IsCloseTo(1, delta=3)
+        ict = IsCloseTo(1, delta=3).resolve()
 
         assert ict.matches(1)
         assert ict.matches(4)
         assert not ict.matches(5)
         assert not ict.matches(-5)
-
-    def test_get_line(self) -> None:
-        num = 1
-        delta = 3
-
-        ict = IsCloseTo(num, delta=delta)
-
-        assert ict.get_line() == f"a value at most {delta} away from {num}."
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsCloseTo(2))
 
 
 class TestIsEqualTo:
@@ -305,13 +263,10 @@ class TestIsEqualTo:
 
     def test_the_test(self) -> None:
         """Matches objects that are equal to what was passed in"""
-        ie = IsEqualTo(1)
+        ie = IsEqualTo(1).resolve()
 
         assert ie.matches(1)
         assert not ie.matches(2)
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsEqualTo(1))
 
 
 class TestIsGreaterThan:
@@ -322,14 +277,11 @@ class TestIsGreaterThan:
 
     def test_the_test(self) -> None:
         test_num = 5
-        igt = IsGreaterThan(test_num)
+        igt = IsGreaterThan(test_num).resolve()
 
         assert igt.matches(test_num + 1)
         assert not igt.matches(test_num)
         assert not igt.matches(test_num - 1)
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsGreaterThan(1))
 
 
 class TestIsGreaterThanOrEqualTo:
@@ -340,14 +292,11 @@ class TestIsGreaterThanOrEqualTo:
 
     def test_the_test(self) -> None:
         test_num = 5
-        igtoet = IsGreaterThanOrEqualTo(test_num)
+        igtoet = IsGreaterThanOrEqualTo(test_num).resolve()
 
         assert igtoet.matches(test_num + 1)
         assert igtoet.matches(test_num)
         assert not igtoet.matches(test_num - 1)
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsGreaterThanOrEqualTo(1))
 
 
 class TestIsInRange:
@@ -361,10 +310,10 @@ class TestIsInRange:
     def test_the_test(self) -> None:
         test_minorant = 5
         test_majorant = 10
-        iir1 = IsInRange(test_minorant, test_majorant)
-        iir2 = IsInRange(f"[{test_minorant}, {test_majorant}]")
-        iir3 = IsInRange(f"({test_minorant}, {test_majorant})")
-        iir4 = IsInRange(f"[{test_minorant}, {test_majorant})")
+        iir1 = IsInRange(test_minorant, test_majorant).resolve()
+        iir2 = IsInRange(f"[{test_minorant}, {test_majorant}]").resolve()
+        iir3 = IsInRange(f"({test_minorant}, {test_majorant})").resolve()
+        iir4 = IsInRange(f"[{test_minorant}, {test_majorant})").resolve()
 
         assert iir1.matches(test_minorant + 1)
         assert iir2.matches(test_minorant + 1)
@@ -387,9 +336,6 @@ class TestIsInRange:
         assert not iir3.matches(test_majorant + 1)
         assert not iir4.matches(test_majorant + 1)
 
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsInRange(1, 5))
-
 
 class TestIsLessThan:
     def test_can_be_instantiated(self) -> None:
@@ -399,14 +345,11 @@ class TestIsLessThan:
 
     def test_the_test(self) -> None:
         test_num = 5
-        ilt = IsLessThan(test_num)
+        ilt = IsLessThan(test_num).resolve()
 
         assert ilt.matches(test_num - 1)
         assert not ilt.matches(test_num)
         assert not ilt.matches(test_num + 1)
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsLessThan(1))
 
 
 class TestIsLessThanOrEqualTo:
@@ -417,14 +360,11 @@ class TestIsLessThanOrEqualTo:
 
     def test_the_test(self) -> None:
         test_num = 5
-        iltoet = IsLessThanOrEqualTo(test_num)
+        iltoet = IsLessThanOrEqualTo(test_num).resolve()
 
         assert iltoet.matches(test_num - 1)
         assert iltoet.matches(test_num)
         assert not iltoet.matches(test_num + 1)
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsLessThanOrEqualTo(1))
 
 
 class TestIsNot:
@@ -435,13 +375,10 @@ class TestIsNot:
 
     def test_the_test(self) -> None:
         """Matches the opposite of what was passed in"""
-        in_ = DoesNot(Equal(1))
+        in_ = DoesNot(Equal(1)).resolve()
 
         assert in_.matches(2)
         assert not in_.matches(1)
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(IsNot(1))
 
 
 class TestMatches:
@@ -451,13 +388,10 @@ class TestMatches:
         assert isinstance(m, Matches)
 
     def test_the_test(self) -> None:
-        m = Matches(r"([Ss]pam ?)+")
+        m = Matches(r"([Ss]pam ?)+").resolve()
 
         assert m.matches("Spam spam spam spam baked beans and spam")
         assert not m.matches("What do you mean Eugh?!")
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(Matches(r"^$"))
 
 
 class TestReadsExactly:
@@ -468,13 +402,10 @@ class TestReadsExactly:
 
     def test_the_test(self) -> None:
         """Matches text exactly"""
-        re_ = ReadsExactly("Blah")
+        re_ = ReadsExactly("Blah").resolve()
 
         assert re_.matches("Blah")
         assert not re_.matches("blah")
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(ReadsExactly("hi"))
 
 
 class TestStartsWith:
@@ -484,10 +415,7 @@ class TestStartsWith:
         assert isinstance(sw, StartsWith)
 
     def test_the_test(self) -> None:
-        sw = StartsWith("I will not buy this record")
+        sw = StartsWith("I will not buy this record").resolve()
 
         assert sw.matches("I will not buy this record, it is scratched.")
         assert not sw.matches("I will not buy this tobacconist, it is scratched.")
-
-    def test_type_hint(self) -> None:
-        assert_matcher_annotation(StartsWith(""))

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -382,7 +382,7 @@ class TestIsLessThanOrEqualTo:
 
 class TestIsNot:
     def test_can_be_instantiated(self) -> None:
-        in_ = IsNot(None)
+        in_ = IsNot(IsEqualTo(True))
 
         assert isinstance(in_, IsNot)
 

--- a/tests/useful_mocks.py
+++ b/tests/useful_mocks.py
@@ -28,14 +28,20 @@ def get_mock_resolution_class() -> Any:
     class FakeResolution(BaseResolution):
         def __new__(cls, *args, **kwargs):
             rt = mock.create_autospec(BaseResolution, instance=True)
+            rt.resolve.return_value = rt
+            rt.describe.return_value = None
             return rt
     return FakeResolution
 
 
 def get_mock_ability_class() -> Any:
-    """
-    This bit of wizardry creates a subclass of Ability that is auto_specced by mock, but
-    still allows for usage in cases where `isinstance` is called without raising exceptions
+    """Generate a mocked Ability class.
+
+    This bit of wizardry creates a subclass of Ability that is auto_specced by
+    mock, but still allows for usage in cases where `isinstance` is called
+    without raising exceptions
+
+    Examples::
 
         MyFakeAbility = get_mock_ability_class()
         fa = MyFakeAbility()


### PR DESCRIPTION
Resolutions have been the odd-duck in ScreenPy for more than 4 whole versions now. It would be nice if they could fit into the paradigm. 

This PR attempts to bring them into the fold by making Resolutions `Resolvable`, and making them look more like all their `-able` siblings.