### PR TITLE
#67: fix consistency between SeeAnyOf and SeeAllOf.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,6 @@ jobs:
           python -m
           poetry
           build
-      - name: Publish distribution to Test PyPI  # always
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI       # only on new tag push
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ target-version = ['py311']
 [tool.poetry]
 name = "screenpy"
 version = "4.1.2"
-description = "Screenplay pattern base for Python automated UI test suites."
+description = "Screenplay pattern base for Python automated test suites."
 authors = ["Perry Goy <perry.goy@gmail.com>"]
 maintainers = ["Gabe Langton", "Marcel Wilson"]
 license = "MIT"

--- a/screenpy/actions/see_all_of.py
+++ b/screenpy/actions/see_all_of.py
@@ -51,19 +51,10 @@ class SeeAllOf:
     @beat("{} sees if {log_message}:")
     def perform_as(self: SelfSeeAllOf, the_actor: Actor) -> None:
         """Direct the Actor to make a series of observations."""
-        all_passed = True
         for question, resolution in self.tests:
-            try:
-                the_actor.should(See.the(question, resolution))
-            except AssertionError:
-                all_passed = False
-
-        if not all_passed:
-            raise AssertionError(f"{the_actor} did not find all expected answers!")
+            the_actor.should(See.the(question, resolution))
 
     def __init__(self: SelfSeeAllOf, *tests: T_T) -> None:
-        if not tests:
-            raise UnableToAct("SeeAllOf was not given any tests.")
         for tup in tests:
             if isinstance(tup, tuple):
                 if len(tup) != 2:
@@ -72,7 +63,9 @@ class SeeAllOf:
                 raise TypeError("Arguments must be tuples.")
 
         self.tests = tests
-        if len(self.tests) == 1:
+        if len(self.tests) == 0:
+            self.log_message = "no tests pass 🤔"
+        elif len(self.tests) == 1:
             self.log_message = "1 test passes"
         else:
             self.log_message = f"all of {len(self.tests)} tests pass"

--- a/screenpy/actions/see_all_of.py
+++ b/screenpy/actions/see_all_of.py
@@ -6,7 +6,7 @@ all of which are expected to be true.
 from typing import Tuple, Type, TypeVar
 
 from screenpy.actor import Actor
-from screenpy.exceptions import DeliveryError, UnableToAct
+from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
 
 from .see import T_Q, T_R, See
@@ -51,9 +51,6 @@ class SeeAllOf:
     @beat("{} sees if {log_message}:")
     def perform_as(self: SelfSeeAllOf, the_actor: Actor) -> None:
         """Direct the Actor to make a series of observations."""
-        if not self.tests:
-            raise DeliveryError("SeeAllOf was not given any tests.")
-
         all_passed = True
         for question, resolution in self.tests:
             try:
@@ -65,6 +62,8 @@ class SeeAllOf:
             raise AssertionError(f"{the_actor} did not find all expected answers!")
 
     def __init__(self: SelfSeeAllOf, *tests: T_T) -> None:
+        if not tests:
+            raise UnableToAct("SeeAllOf was not given any tests.")
         for tup in tests:
             if isinstance(tup, tuple):
                 if len(tup) != 2:
@@ -73,9 +72,7 @@ class SeeAllOf:
                 raise TypeError("Arguments must be tuples.")
 
         self.tests = tests
-        if len(self.tests) == 0:
-            self.log_message = "no tests pass 🤔"
-        elif len(self.tests) == 1:
+        if len(self.tests) == 1:
             self.log_message = "1 test passes"
         else:
             self.log_message = f"all of {len(self.tests)} tests pass"

--- a/screenpy/actions/see_any_of.py
+++ b/screenpy/actions/see_any_of.py
@@ -52,20 +52,18 @@ class SeeAnyOf:
     @beat("{} sees if {log_message}:")
     def perform_as(self: SelfSeeAnyOf, the_actor: Actor) -> None:
         """Direct the Actor to make a series of observations."""
-        none_passed = True
         for question, resolution in self.tests:
             try:
                 the_actor.should(See.the(question, resolution))
-                none_passed = False
+                break
             except AssertionError:
                 pass  # well, not *pass*, but... you get it.
-
-        if none_passed:
-            raise AssertionError(f"{the_actor} did not find any expected answers!")
+        else:
+            # none passed!
+            msg = f"{the_actor} did not find any expected answers!"
+            raise AssertionError(msg)
 
     def __init__(self: SelfSeeAnyOf, *tests: T_T) -> None:
-        if not tests:
-            raise UnableToAct("SeeAnyOf was not given any tests.")
         for tup in tests:
             if isinstance(tup, tuple):
                 if len(tup) != 2:
@@ -74,7 +72,9 @@ class SeeAnyOf:
                 raise TypeError("Arguments must be tuples")
 
         self.tests = tests
-        if len(self.tests) == 1:
+        if len(self.tests) == 0:
+            self.log_message = "no tests pass 🤔"
+        elif len(self.tests) == 1:
             self.log_message = "1 test passes"
         else:
             self.log_message = f"any of {len(self.tests)} tests pass"

--- a/screenpy/actions/see_any_of.py
+++ b/screenpy/actions/see_any_of.py
@@ -6,7 +6,7 @@ at least one of which is expected to be true.
 from typing import Tuple, Type, TypeVar
 
 from screenpy.actor import Actor
-from screenpy.exceptions import UnableToAct
+from screenpy.exceptions import DeliveryError, UnableToAct
 from screenpy.pacing import beat
 
 from .see import T_Q, T_R, See
@@ -52,6 +52,9 @@ class SeeAnyOf:
     @beat("{} sees if {log_message}:")
     def perform_as(self: SelfSeeAnyOf, the_actor: Actor) -> None:
         """Direct the Actor to make a series of observations."""
+        if not self.tests:
+            raise DeliveryError("SeeAnyOf was not given any tests.")
+
         none_passed = True
         for question, resolution in self.tests:
             try:

--- a/screenpy/actions/see_any_of.py
+++ b/screenpy/actions/see_any_of.py
@@ -6,7 +6,7 @@ at least one of which is expected to be true.
 from typing import Tuple, Type, TypeVar
 
 from screenpy.actor import Actor
-from screenpy.exceptions import DeliveryError, UnableToAct
+from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
 
 from .see import T_Q, T_R, See
@@ -52,9 +52,6 @@ class SeeAnyOf:
     @beat("{} sees if {log_message}:")
     def perform_as(self: SelfSeeAnyOf, the_actor: Actor) -> None:
         """Direct the Actor to make a series of observations."""
-        if not self.tests:
-            raise DeliveryError("SeeAnyOf was not given any tests.")
-
         none_passed = True
         for question, resolution in self.tests:
             try:
@@ -67,6 +64,8 @@ class SeeAnyOf:
             raise AssertionError(f"{the_actor} did not find any expected answers!")
 
     def __init__(self: SelfSeeAnyOf, *tests: T_T) -> None:
+        if not tests:
+            raise UnableToAct("SeeAnyOf was not given any tests.")
         for tup in tests:
             if isinstance(tup, tuple):
                 if len(tup) != 2:
@@ -75,9 +74,7 @@ class SeeAnyOf:
                 raise TypeError("Arguments must be tuples")
 
         self.tests = tests
-        if len(self.tests) == 0:
-            self.log_message = "no tests pass 🤔"
-        elif len(self.tests) == 1:
+        if len(self.tests) == 1:
             self.log_message = "1 test passes"
         else:
             self.log_message = f"any of {len(self.tests)} tests pass"

--- a/screenpy/actions/see_any_of.py
+++ b/screenpy/actions/see_any_of.py
@@ -52,6 +52,10 @@ class SeeAnyOf:
     @beat("{} sees if {log_message}:")
     def perform_as(self: SelfSeeAnyOf, the_actor: Actor) -> None:
         """Direct the Actor to make a series of observations."""
+        if not self.tests:
+            # No tests is OK!
+            return
+
         for question, resolution in self.tests:
             try:
                 the_actor.should(See.the(question, resolution))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-from typing import Any, Callable, Generator
+from typing import Any, Generator
 from unittest import mock
 
 import pytest
 
-from screenpy import Actor, Narrator, pacing, settings
+from screenpy import Actor, Narrator, pacing
 
 
 @pytest.fixture(scope="function")
@@ -24,23 +24,3 @@ def mocked_narrator() -> Generator[mock.MagicMock, Any, None]:
     yield mock_narrator
 
     pacing.the_narrator = old_narrator
-
-
-def mock_settings(**new_settings) -> Callable:
-    """Mock one or more settings for the duration of a test."""
-
-    def decorator(func: Callable) -> Callable:
-        def wrapper(*args, **kwargs):
-            old_settings = {key: getattr(settings, key) for key in new_settings.keys()}
-            for key, value in new_settings.items():
-                setattr(settings, key, value)
-
-            try:
-                func(*args, **kwargs)
-            finally:
-                for key, value in old_settings.items():
-                    setattr(settings, key, value)
-
-        return wrapper
-
-    return decorator

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -542,6 +542,9 @@ class TestSeeAllOf:
         with pytest.raises(UnableToAct):
             SeeAllOf((FakeQuestion(), FakeResolution(), 1))  # type: ignore
 
+    def test_passes_with_zero_tests(self, Tester) -> None:
+        SeeAllOf().perform_as(Tester)  # no exception means this test passes
+
     @mock.patch("screenpy.actions.see_all_of.See")
     def test_calls_see_for_each_test(self, MockedSee, Tester) -> None:
         num_tests = 3
@@ -622,6 +625,9 @@ class TestSeeAnyOf:
 
         with pytest.raises(UnableToAct):
             SeeAnyOf((FakeQuestion(), FakeResolution(), 1))  # type: ignore
+
+    def test_passes_with_zero_tests(self, Tester) -> None:
+        SeeAnyOf().perform_as(Tester)  # no exception means this test passes
 
     @mock.patch("screenpy.actions.see_any_of.See")
     def test_calls_see_for_each_test(self, MockedSee, Tester) -> None:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -567,7 +567,7 @@ class TestSeeAllOf:
             ).perform_as(Tester)
 
     def test_raises_for_no_tests(self, Tester) -> None:
-        with pytest.raises(DeliveryError):
+        with pytest.raises(UnableToAct):
             SeeAllOf().perform_as(Tester)
 
     def test_performs_all_tests(self, Tester) -> None:
@@ -601,7 +601,6 @@ class TestSeeAllOf:
             (FakeQuestion(), IsEqualTo(True)),
         )
 
-        assert SeeAllOf().describe() == "See if no tests pass 🤔."
         assert SeeAllOf(test).describe() == "See if 1 test passes."
         assert SeeAllOf(*tests).describe() == f"See if all of {len(tests)} tests pass."
 
@@ -654,7 +653,7 @@ class TestSeeAnyOf:
         assert "did not find any expected answers" in str(actual_exception)
 
     def test_raises_for_no_tests(self, Tester) -> None:
-        with pytest.raises(DeliveryError):
+        with pytest.raises(UnableToAct):
             SeeAnyOf().perform_as(Tester)
 
     def test_performs_all_tests(self, Tester) -> None:
@@ -687,7 +686,6 @@ class TestSeeAnyOf:
             (FakeQuestion(), IsEqualTo(True)),
         )
 
-        assert SeeAnyOf().describe() == "See if no tests pass 🤔."
         assert SeeAnyOf(test).describe() == "See if 1 test passes."
         assert SeeAnyOf(*tests).describe() == f"See if any of {len(tests)} tests pass."
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -566,6 +566,23 @@ class TestSeeAllOf:
                 (FakeQuestion(), IsEqualTo(True)),
             ).perform_as(Tester)
 
+    def test_raises_for_no_tests(self, Tester) -> None:
+        with pytest.raises(DeliveryError):
+            SeeAllOf().perform_as(Tester)
+
+    def test_performs_all_tests(self, Tester) -> None:
+        mock_question = FakeQuestion()
+
+        with pytest.raises(AssertionError):
+            SeeAllOf(
+                (mock_question, IsEqualTo(True)),
+                (mock_question, IsEqualTo(False)),  # <--
+                (mock_question, IsEqualTo(True)),
+                (mock_question, IsEqualTo(True)),
+            ).perform_as(Tester)
+
+        assert mock_question.answered_by.call_count == 4
+
     def test_passes_if_all_pass(self, Tester) -> None:
         # test passes if no exception is raised
         SeeAllOf(
@@ -635,6 +652,22 @@ class TestSeeAnyOf:
             ).perform_as(Tester)
 
         assert "did not find any expected answers" in str(actual_exception)
+
+    def test_raises_for_no_tests(self, Tester) -> None:
+        with pytest.raises(DeliveryError):
+            SeeAnyOf().perform_as(Tester)
+
+    def test_performs_all_tests(self, Tester) -> None:
+        mock_question = FakeQuestion()
+
+        SeeAnyOf(
+            (mock_question, IsEqualTo(True)),
+            (mock_question, IsEqualTo(True)),
+            (mock_question, IsEqualTo(True)),
+            (mock_question, IsEqualTo(True)),
+        ).perform_as(Tester)
+
+        assert mock_question.answered_by.call_count == 4
 
     def test_passes_with_one_pass(self, Tester) -> None:
         # test passes if no exception is raised

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -596,6 +596,7 @@ class TestSeeAllOf:
             (FakeQuestion(), IsEqualTo(True)),
         )
 
+        assert SeeAllOf().describe() == "See if no tests pass 🤔."
         assert SeeAllOf(test).describe() == "See if 1 test passes."
         assert SeeAllOf(*tests).describe() == f"See if all of {len(tests)} tests pass."
 
@@ -681,6 +682,7 @@ class TestSeeAnyOf:
             (FakeQuestion(), IsEqualTo(True)),
         )
 
+        assert SeeAnyOf().describe() == "See if no tests pass 🤔."
         assert SeeAnyOf(test).describe() == "See if 1 test passes."
         assert SeeAnyOf(*tests).describe() == f"See if any of {len(tests)} tests pass."
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -96,6 +96,7 @@ class TestAttachTheFile:
 
     def test_describe(self) -> None:
         file = "somefile.txt"
+
         assert AttachTheFile(file).describe() == f"Attach a file named {file}."
 
 
@@ -196,6 +197,7 @@ class TestEventually:
 
     def test_can_adjust_timeout_and_polling(self) -> None:
         ev = Eventually(FakeAction()).trying_for(23).seconds().polling(3).second()
+
         assert ev.timeout == 23
         assert ev.poll == 3
 
@@ -297,14 +299,10 @@ class TestEventually:
     def test_describe(self) -> None:
         mock_action = FakeAction()
         mock_action.describe.return_value = "An African or a European swallow?"
+
         assert (
             Eventually(mock_action).describe()
             == "Eventually an African or a European swallow."
-        )
-
-    def test_describe_none(self) -> None:
-        assert (
-            Eventually(FakeAction()).describe() == "Eventually something indescribable."
         )
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,13 +1,11 @@
 import logging
 import os
-import sys
 import time
 from unittest import mock
 
 import pytest
 from pytest_mock import MockerFixture
 
-from conftest import mock_settings
 from screenpy import (
     Actor,
     Answerable,
@@ -41,6 +39,7 @@ from screenpy.actions.silently import (
     SilentlyPerformable,
     SilentlyResolvable,
 )
+from screenpy.test_utils import mock_settings
 from unittest_protocols import ErrorQuestion
 from useful_mocks import (
     get_mock_action_class,


### PR DESCRIPTION
This PR ensures both `SeeAnyOf` and `SeeAllOf` behave consistently:
 * Both will now raise a `UnableToAct` if they were not given any tests.
 * Both will now execute all tests given to them, even if `SeeAnyOf` encounters a pass or `SeeAllOf` encounters a failure.

... and those were the two ways they were inconsistent! Well one way they were inconsistent and one new thing to handle.