### PR TITLE
#81: Add github action to publish to PyPI.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
           build
       - name: Publish distribution to Test PyPI  # always
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI       # only on new tag push
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+# adapted from https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# with changes from https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+
+name: Publish to PyPI
+
+on: push
+
+jobs:
+  build-and-pypi-publish:
+    name: Build and upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install Poetry
+        run: >-
+          python -m
+          pip install
+          poetry
+          --user
+      - name: Build ScreenPy
+        run: >-
+          python -m
+          poetry
+          build
+      - name: Publish distribution to Test PyPI  # always
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish distribution to PyPI       # only on new tag push
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I think this will work, maybe. I'm not sure. Let's find out!

This PR adds a new Github Action to publish ScreenPy to PyPI when a new tag is pushed up. Historically i've only published a new tag during the deployment process, so this ties in nicely with the typical tagging procedure we've followed on ScreenPy. Plus, now we can cut new versions just by pushing a new tag!