### PR TITLE
represent various objects when logging better

### DIFF
--- a/screenpy/actions/make_note.py
+++ b/screenpy/actions/make_note.py
@@ -9,6 +9,7 @@ from screenpy.director import Director
 from screenpy.exceptions import UnableToAct
 from screenpy.pacing import aside, beat
 from screenpy.protocols import Answerable, ErrorKeeper
+from screenpy.speech_tools import represent_prop
 
 SelfMakeNote = TypeVar("SelfMakeNote", bound="MakeNote")
 T_Q = Union[Answerable, object]
@@ -54,9 +55,9 @@ class MakeNote:
 
     def describe(self: SelfMakeNote) -> str:
         """Describe the Action in present tense."""
-        return f"Make a note under {self.key}."
+        return f"Make a note under {represent_prop(self.key)}."
 
-    @beat('{} jots something down under "{key}".')
+    @beat("{} jots something down under {key_to_log}.")
     def perform_as(self: SelfMakeNote, the_actor: Actor) -> None:
         """Direct the Actor to take a note."""
         if self.key is None:
@@ -81,3 +82,4 @@ class MakeNote:
     ) -> None:
         self.question = question
         self.key = key
+        self.key_to_log = represent_prop(key)

--- a/screenpy/actions/see.py
+++ b/screenpy/actions/see.py
@@ -9,7 +9,7 @@ from hamcrest import assert_that
 from screenpy.actor import Actor
 from screenpy.pacing import aside, beat
 from screenpy.protocols import Answerable, ErrorKeeper, Resolvable
-from screenpy.speech_tools import get_additive_description
+from screenpy.speech_tools import get_additive_description, tostring
 
 SelfSee = TypeVar("SelfSee", bound="See")
 T_Q = Union[Answerable, object]
@@ -56,7 +56,7 @@ class See:
         else:
             # must be a value instead of a question!
             value = self.question
-            aside(f"the actual value is: {value}")
+            aside(f"the actual value is: {tostring(value)}")
 
         reason = ""
         if isinstance(self.question, ErrorKeeper):

--- a/screenpy/actions/see.py
+++ b/screenpy/actions/see.py
@@ -9,7 +9,7 @@ from hamcrest import assert_that
 from screenpy.actor import Actor
 from screenpy.pacing import aside, beat
 from screenpy.protocols import Answerable, ErrorKeeper, Resolvable
-from screenpy.speech_tools import get_additive_description, tostring
+from screenpy.speech_tools import get_additive_description, represent_prop
 
 SelfSee = TypeVar("SelfSee", bound="See")
 T_Q = Union[Answerable, object]
@@ -56,7 +56,7 @@ class See:
         else:
             # must be a value instead of a question!
             value = self.question
-            aside(f"the actual value is: {tostring(value)}")
+            aside(f"the actual value is: {represent_prop(value)}")
 
         reason = ""
         if isinstance(self.question, ErrorKeeper):

--- a/screenpy/pacing.py
+++ b/screenpy/pacing.py
@@ -9,7 +9,7 @@ from functools import wraps
 from typing import Any, Callable, Optional
 
 from screenpy.narration import Narrator, StdOutAdapter
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 Function = Callable[..., Any]
 the_narrator: Narrator = Narrator(adapters=[StdOutAdapter()])
@@ -89,7 +89,7 @@ def beat(line: str, gravitas: Optional[str] = None) -> Callable[[Function], Func
             with the_narrator.stating_a_beat(func, completed_line, gravitas) as n_func:
                 retval = n_func(*args, **kwargs)
                 if retval is not None:
-                    aside(f"=> {tostring(retval)}")
+                    aside(f"=> {represent_prop(retval)}")
             return retval
 
         return wrapper

--- a/screenpy/pacing.py
+++ b/screenpy/pacing.py
@@ -9,6 +9,7 @@ from functools import wraps
 from typing import Any, Callable, Optional
 
 from screenpy.narration import Narrator, StdOutAdapter
+from screenpy.speech_tools import tostring
 
 Function = Callable[..., Any]
 the_narrator: Narrator = Narrator(adapters=[StdOutAdapter()])
@@ -88,7 +89,7 @@ def beat(line: str, gravitas: Optional[str] = None) -> Callable[[Function], Func
             with the_narrator.stating_a_beat(func, completed_line, gravitas) as n_func:
                 retval = n_func(*args, **kwargs)
                 if retval is not None:
-                    aside(f"=> {retval}")
+                    aside(f"=> {tostring(retval)}")
             return retval
 
         return wrapper

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -9,6 +9,7 @@ from hamcrest.core.matcher import Matcher
 
 from screenpy.exceptions import UnableToFormResolution
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
@@ -79,5 +80,5 @@ class ContainsTheEntry:
                 self.entries = dict(pairs, **kv_kwargs)
         self.entry_plural = "entries" if len(self.entries) != 1 else "entry"
         self.entries_to_log = ", ".join(
-            f"{k!r}->{v!r}" for k, v in self.entries.items()
+            f"{tostring(k)}->{tostring(v)}" for k, v in self.entries.items()
         )

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -9,7 +9,7 @@ from hamcrest.core.matcher import Matcher
 
 from screenpy.exceptions import UnableToFormResolution
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
@@ -80,5 +80,5 @@ class ContainsTheEntry:
                 self.entries = dict(pairs, **kv_kwargs)
         self.entry_plural = "entries" if len(self.entries) != 1 else "entry"
         self.entries_to_log = ", ".join(
-            f"{tostring(k)}->{tostring(v)}" for k, v in self.entries.items()
+            f"{represent_prop(k)}->{represent_prop(v)}" for k, v in self.entries.items()
         )

--- a/screenpy/resolutions/contains_the_entry.py
+++ b/screenpy/resolutions/contains_the_entry.py
@@ -78,4 +78,6 @@ class ContainsTheEntry:
                 ]
                 self.entries = dict(pairs, **kv_kwargs)
         self.entry_plural = "entries" if len(self.entries) != 1 else "entry"
-        self.entries_to_log = ", ".join(f"{k}->{v}" for k, v in self.entries.items())
+        self.entries_to_log = ", ".join(
+            f"{k!r}->{v!r}" for k, v in self.entries.items()
+        )

--- a/screenpy/resolutions/contains_the_item.py
+++ b/screenpy/resolutions/contains_the_item.py
@@ -8,7 +8,7 @@ from hamcrest import has_item
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 T = TypeVar("T")
 
@@ -34,4 +34,4 @@ class ContainsTheItem:
 
     def __init__(self, item: T) -> None:
         self.item = item
-        self.item_to_log = tostring(item)
+        self.item_to_log = represent_prop(item)

--- a/screenpy/resolutions/contains_the_item.py
+++ b/screenpy/resolutions/contains_the_item.py
@@ -25,17 +25,13 @@ class ContainsTheItem:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"A sequence containing {tostring(self.item)}."
+        return f"A sequence containing {self.item_to_log}."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it contains {tostring(self.item)}."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it contains {item_to_log}.")
     def resolve(self) -> Matcher[Sequence[T]]:
         """Produce the Matcher to make the assertion."""
         return has_item(self.item)
 
     def __init__(self, item: T) -> None:
         self.item = item
+        self.item_to_log = tostring(item)

--- a/screenpy/resolutions/contains_the_item.py
+++ b/screenpy/resolutions/contains_the_item.py
@@ -8,6 +8,7 @@ from hamcrest import has_item
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 T = TypeVar("T")
 
@@ -24,9 +25,14 @@ class ContainsTheItem:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'A sequence containing "{self.item}".'
+        return f"A sequence containing {tostring(self.item)}."
 
-    @beat('... hoping it contains "{item}".')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it contains {tostring(self.item)}."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[Sequence[T]]:
         """Produce the Matcher to make the assertion."""
         return has_item(self.item)

--- a/screenpy/resolutions/contains_the_key.py
+++ b/screenpy/resolutions/contains_the_key.py
@@ -8,6 +8,7 @@ from hamcrest import has_key
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 K = TypeVar("K", bound=Hashable)
 
@@ -22,9 +23,14 @@ class ContainsTheKey(Generic[K]):
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'Containing the key "{self.key}".'
+        return f"Containing the key {tostring(self.key)}."
 
-    @beat('... hoping it\'s a dict containing the key "{key}".')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it's a dict containing the key {tostring(self.key)}."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[Mapping[K, Any]]:
         """Produce the Matcher to make the assertion."""
         return has_key(self.key)

--- a/screenpy/resolutions/contains_the_key.py
+++ b/screenpy/resolutions/contains_the_key.py
@@ -8,7 +8,7 @@ from hamcrest import has_key
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 K = TypeVar("K", bound=Hashable)
 
@@ -32,4 +32,4 @@ class ContainsTheKey(Generic[K]):
 
     def __init__(self, key: K) -> None:
         self.key = key
-        self.key_to_log = tostring(key)
+        self.key_to_log = represent_prop(key)

--- a/screenpy/resolutions/contains_the_key.py
+++ b/screenpy/resolutions/contains_the_key.py
@@ -23,17 +23,13 @@ class ContainsTheKey(Generic[K]):
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Containing the key {tostring(self.key)}."
+        return f"Containing the key {self.key_to_log}."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it's a dict containing the key {tostring(self.key)}."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it's a dict containing the key {key_to_log}.")
     def resolve(self) -> Matcher[Mapping[K, Any]]:
         """Produce the Matcher to make the assertion."""
         return has_key(self.key)
 
     def __init__(self, key: K) -> None:
         self.key = key
+        self.key_to_log = tostring(key)

--- a/screenpy/resolutions/contains_the_text.py
+++ b/screenpy/resolutions/contains_the_text.py
@@ -6,6 +6,7 @@ from hamcrest import contains_string
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 
 class ContainsTheText:
@@ -20,9 +21,14 @@ class ContainsTheText:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'Containing the text "{self.text}".'
+        return f"Containing the text {tostring(self.text)}."
 
-    @beat('... hoping it contains "{text}".')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it contains {tostring(self.text)}."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return contains_string(self.text)

--- a/screenpy/resolutions/contains_the_text.py
+++ b/screenpy/resolutions/contains_the_text.py
@@ -21,17 +21,13 @@ class ContainsTheText:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Containing the text {tostring(self.text)}."
+        return f"Containing the text {self.text_to_log}."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it contains {tostring(self.text)}."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it contains {text_to_log}.")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return contains_string(self.text)
 
     def __init__(self, text: str) -> None:
         self.text = text
+        self.text_to_log = tostring(text)

--- a/screenpy/resolutions/contains_the_text.py
+++ b/screenpy/resolutions/contains_the_text.py
@@ -6,7 +6,7 @@ from hamcrest import contains_string
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 
 class ContainsTheText:
@@ -30,4 +30,4 @@ class ContainsTheText:
 
     def __init__(self, text: str) -> None:
         self.text = text
-        self.text_to_log = tostring(text)
+        self.text_to_log = represent_prop(text)

--- a/screenpy/resolutions/contains_the_value.py
+++ b/screenpy/resolutions/contains_the_value.py
@@ -8,6 +8,7 @@ from hamcrest import has_value
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 V = TypeVar("V")
 
@@ -24,9 +25,14 @@ class ContainsTheValue(Generic[V]):
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'Containing the value "{self.value}".'
+        return f"Containing the value {tostring(self.value)}."
 
-    @beat('... hoping it contains the value "{value}".')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it contains the value {tostring(self.value)}."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[Mapping[Any, V]]:
         """Produce the Matcher to form the assertion."""
         return has_value(self.value)

--- a/screenpy/resolutions/contains_the_value.py
+++ b/screenpy/resolutions/contains_the_value.py
@@ -25,17 +25,13 @@ class ContainsTheValue(Generic[V]):
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Containing the value {tostring(self.value)}."
+        return f"Containing the value {self.value_to_log}."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it contains the value {tostring(self.value)}."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it contains the value {value_to_log}.")
     def resolve(self) -> Matcher[Mapping[Any, V]]:
         """Produce the Matcher to form the assertion."""
         return has_value(self.value)
 
     def __init__(self, value: V) -> None:
         self.value = value
+        self.value_to_log = tostring(value)

--- a/screenpy/resolutions/contains_the_value.py
+++ b/screenpy/resolutions/contains_the_value.py
@@ -8,7 +8,7 @@ from hamcrest import has_value
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 V = TypeVar("V")
 
@@ -34,4 +34,4 @@ class ContainsTheValue(Generic[V]):
 
     def __init__(self, value: V) -> None:
         self.value = value
-        self.value_to_log = tostring(value)
+        self.value_to_log = represent_prop(value)

--- a/screenpy/resolutions/custom_matchers/sequence_containing_pattern.py
+++ b/screenpy/resolutions/custom_matchers/sequence_containing_pattern.py
@@ -28,7 +28,7 @@ class IsSequenceContainingPattern(BaseMatcher[Sequence[str]]):
     def describe_to(self, description: Description) -> None:
         """Describe the passing case."""
         description.append_text(
-            f"a sequence containing an element which matches {self.pattern}"
+            f'a sequence containing an element which matches r"{self.pattern}"'
         )
 
     def describe_match(self, _: Sequence[str], match_description: Description) -> None:
@@ -43,7 +43,7 @@ class IsSequenceContainingPattern(BaseMatcher[Sequence[str]]):
             mismatch_description.append_text("was not a sequence")
             return
         mismatch_description.append_text(
-            f"did not contain an item matching {self.pattern}"
+            f'did not contain an item matching r"{self.pattern}"'
         )
 
 

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -6,6 +6,7 @@ from hamcrest import ends_with
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 
 class EndsWith:
@@ -20,9 +21,14 @@ class EndsWith:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'Ending with "{self.postfix}".'
+        return f"Ending with {tostring(self.postfix)}."
 
-    @beat('... hoping it ends with "{postfix}".')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it ends with {tostring(self.postfix)}."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return ends_with(self.postfix)

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -21,17 +21,13 @@ class EndsWith:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Ending with {tostring(self.postfix)}."
+        return f"Ending with {self.postfix_to_log}."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it ends with {tostring(self.postfix)}."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it ends with {postfix_to_log}.")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return ends_with(self.postfix)
 
     def __init__(self, postfix: str) -> None:
         self.postfix = postfix
+        self.postfix_to_log = tostring(postfix)

--- a/screenpy/resolutions/ends_with.py
+++ b/screenpy/resolutions/ends_with.py
@@ -6,7 +6,7 @@ from hamcrest import ends_with
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 
 class EndsWith:
@@ -30,4 +30,4 @@ class EndsWith:
 
     def __init__(self, postfix: str) -> None:
         self.postfix = postfix
-        self.postfix_to_log = tostring(postfix)
+        self.postfix_to_log = represent_prop(postfix)

--- a/screenpy/resolutions/is_equal_to.py
+++ b/screenpy/resolutions/is_equal_to.py
@@ -8,6 +8,7 @@ from hamcrest import equal_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import represent_prop
 
 
 class IsEqualTo:
@@ -22,12 +23,13 @@ class IsEqualTo:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Equal to {self.expected}."
+        return f"Equal to {self.expected_to_log}."
 
-    @beat("... hoping it's equal to {expected}.")
+    @beat("... hoping it's equal to {expected_to_log}.")
     def resolve(self) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""
         return equal_to(self.expected)
 
     def __init__(self, obj: Any) -> None:
         self.expected = obj
+        self.expected_to_log = represent_prop(obj)

--- a/screenpy/resolutions/is_greater_than.py
+++ b/screenpy/resolutions/is_greater_than.py
@@ -8,6 +8,7 @@ from hamcrest import greater_than
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import represent_prop
 
 
 class IsGreaterThan:
@@ -20,12 +21,13 @@ class IsGreaterThan:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Greater than {self.number}."
+        return f"Greater than {self.number_to_log}."
 
-    @beat("... hoping it's greater than {number}.")
+    @beat("... hoping it's greater than {number_to_log}.")
     def resolve(self) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""
         return greater_than(self.number)
 
     def __init__(self, number: float) -> None:
         self.number = number
+        self.number_to_log = represent_prop(number)

--- a/screenpy/resolutions/is_greater_than_or_equal_to.py
+++ b/screenpy/resolutions/is_greater_than_or_equal_to.py
@@ -8,6 +8,7 @@ from hamcrest import greater_than_or_equal_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import represent_prop
 
 
 class IsGreaterThanOrEqualTo:
@@ -22,12 +23,13 @@ class IsGreaterThanOrEqualTo:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Greater than or equal to {self.number}."
+        return f"Greater than or equal to {self.number_to_log}."
 
-    @beat("... hoping it's greater than or equal to {number}.")
+    @beat("... hoping it's greater than or equal to {number_to_log}.")
     def resolve(self) -> Matcher[Any]:
         """Produce the Matcher to make the assertion."""
         return greater_than_or_equal_to(self.number)
 
     def __init__(self, number: float) -> None:
         self.number = number
+        self.number_to_log = represent_prop(number)

--- a/screenpy/resolutions/is_less_than.py
+++ b/screenpy/resolutions/is_less_than.py
@@ -6,6 +6,7 @@ from hamcrest import less_than
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import represent_prop
 
 
 class IsLessThan:
@@ -20,12 +21,13 @@ class IsLessThan:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Less than {self.number}."
+        return f"Less than {self.number_to_log}."
 
-    @beat("... hoping it's less than {number}.")
+    @beat("... hoping it's less than {number_to_log}.")
     def resolve(self) -> Matcher[float]:
         """Produce the Matcher to make the assertion."""
         return less_than(self.number)
 
     def __init__(self, number: float) -> None:
         self.number = number
+        self.number_to_log = represent_prop(number)

--- a/screenpy/resolutions/is_less_than_or_equal_to.py
+++ b/screenpy/resolutions/is_less_than_or_equal_to.py
@@ -6,6 +6,7 @@ from hamcrest import less_than_or_equal_to
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import represent_prop
 
 
 class IsLessThanOrEqualTo:
@@ -20,12 +21,13 @@ class IsLessThanOrEqualTo:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Less than or equal to {self.number}."
+        return f"Less than or equal to {self.number_to_log}."
 
-    @beat("... hoping it's less than or equal to {number}.")
+    @beat("... hoping it's less than or equal to {number_to_log}.")
     def resolve(self) -> Matcher[float]:
         """Produce the Matcher to make the assertion."""
         return less_than_or_equal_to(self.number)
 
     def __init__(self, number: float) -> None:
         self.number = number
+        self.number_to_log = represent_prop(number)

--- a/screenpy/resolutions/reads_exactly.py
+++ b/screenpy/resolutions/reads_exactly.py
@@ -6,6 +6,7 @@ from hamcrest import has_string
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 
 class ReadsExactly:
@@ -20,9 +21,14 @@ class ReadsExactly:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'"{self.text}", verbatim.'
+        return f"{tostring(self.text)}, verbatim."
 
-    @beat('... hoping it\'s "{text}", verbatim.')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it's {tostring(self.text)}, verbatim."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[object]:
         """Produce the Matcher to make the assertion."""
         return has_string(self.text)

--- a/screenpy/resolutions/reads_exactly.py
+++ b/screenpy/resolutions/reads_exactly.py
@@ -21,17 +21,13 @@ class ReadsExactly:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"{tostring(self.text)}, verbatim."
+        return f"{self.text_to_log}, verbatim."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it's {tostring(self.text)}, verbatim."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it's {text_to_log}, verbatim.")
     def resolve(self) -> Matcher[object]:
         """Produce the Matcher to make the assertion."""
         return has_string(self.text)
 
     def __init__(self, text: str) -> None:
         self.text = text
+        self.text_to_log = tostring(text)

--- a/screenpy/resolutions/reads_exactly.py
+++ b/screenpy/resolutions/reads_exactly.py
@@ -6,7 +6,7 @@ from hamcrest import has_string
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 
 class ReadsExactly:
@@ -30,4 +30,4 @@ class ReadsExactly:
 
     def __init__(self, text: str) -> None:
         self.text = text
-        self.text_to_log = tostring(text)
+        self.text_to_log = represent_prop(text)

--- a/screenpy/resolutions/starts_with.py
+++ b/screenpy/resolutions/starts_with.py
@@ -21,17 +21,13 @@ class StartsWith:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Starting with {tostring(self.prefix)}."
+        return f"Starting with {self.prefix_to_log}."
 
-    @property
-    def beatmsg(self) -> str:
-        """format string meant for beat msg"""
-        return f"... hoping it starts with {tostring(self.prefix)}."
-
-    @beat("{beatmsg}")
+    @beat("... hoping it starts with {prefix_to_log}.")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return starts_with(self.prefix)
 
     def __init__(self, prefix: str) -> None:
         self.prefix = prefix
+        self.prefix_to_log = tostring(prefix)

--- a/screenpy/resolutions/starts_with.py
+++ b/screenpy/resolutions/starts_with.py
@@ -6,7 +6,7 @@ from hamcrest import starts_with
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
-from screenpy.speech_tools import tostring
+from screenpy.speech_tools import represent_prop
 
 
 class StartsWith:
@@ -30,4 +30,4 @@ class StartsWith:
 
     def __init__(self, prefix: str) -> None:
         self.prefix = prefix
-        self.prefix_to_log = tostring(prefix)
+        self.prefix_to_log = represent_prop(prefix)

--- a/screenpy/resolutions/starts_with.py
+++ b/screenpy/resolutions/starts_with.py
@@ -6,6 +6,7 @@ from hamcrest import starts_with
 from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+from screenpy.speech_tools import tostring
 
 
 class StartsWith:
@@ -20,9 +21,14 @@ class StartsWith:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'Starting with "{self.prefix}".'
+        return f"Starting with {tostring(self.prefix)}."
 
-    @beat('... hoping it starts with "{prefix}".')
+    @property
+    def beatmsg(self) -> str:
+        """format string meant for beat msg"""
+        return f"... hoping it starts with {tostring(self.prefix)}."
+
+    @beat("{beatmsg}")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return starts_with(self.prefix)

--- a/screenpy/speech_tools.py
+++ b/screenpy/speech_tools.py
@@ -3,12 +3,14 @@ A grab-bag of useful language-massaging functions with broad applicability.
 """
 
 import re
-from typing import Any, Union
+from typing import TypeVar, Union, overload
 
 from screenpy.protocols import Answerable, Describable, Performable, Resolvable
 
+T = TypeVar("T")
 
-def get_additive_description(describable: Union[Describable, Any]) -> str:
+
+def get_additive_description(describable: Union[Describable, T]) -> str:
     """Extract a description that can be placed within a sentence.
 
     The ``describe`` method of Describables will provide a description,
@@ -44,3 +46,20 @@ def get_additive_description(describable: Union[Describable, Any]) -> str:
         description = f"the {describable.__class__.__name__}"
 
     return description
+
+
+@overload
+def tostring(item: str) -> str:
+    ...
+
+
+@overload
+def tostring(item: T) -> T:
+    ...
+
+
+def tostring(item: str | T) -> str | T:
+    """help convert objects to a proper format for logging"""
+    if isinstance(item, str):
+        return repr(item)
+    return item

--- a/screenpy/speech_tools.py
+++ b/screenpy/speech_tools.py
@@ -49,17 +49,17 @@ def get_additive_description(describable: Union[Describable, T]) -> str:
 
 
 @overload
-def tostring(item: str) -> str:
+def represent_prop(item: str) -> str:
     ...
 
 
 @overload
-def tostring(item: T) -> T:
+def represent_prop(item: T) -> T:
     ...
 
 
-def tostring(item: Union[str, T]) -> Union[str, T]:
-    """help convert objects to a proper format for logging"""
+def represent_prop(item: Union[str, T]) -> Union[str, T]:
+    """represent items in a manner suitable for the audience (logging)"""
     if isinstance(item, str):
         return repr(item)
     return item

--- a/screenpy/speech_tools.py
+++ b/screenpy/speech_tools.py
@@ -58,7 +58,7 @@ def tostring(item: T) -> T:
     ...
 
 
-def tostring(item: str | T) -> str | T:
+def tostring(item: Union[str, T]) -> Union[str, T]:
     """help convert objects to a proper format for logging"""
     if isinstance(item, str):
         return repr(item)

--- a/screenpy/speech_tools.py
+++ b/screenpy/speech_tools.py
@@ -5,6 +5,9 @@ A grab-bag of useful language-massaging functions with broad applicability.
 import re
 from typing import TypeVar, Union, overload
 
+from hamcrest.core.helpers.hasmethod import hasmethod
+from hamcrest.core.helpers.ismock import ismock
+
 from screenpy.protocols import Answerable, Describable, Performable, Resolvable
 
 T = TypeVar("T")
@@ -60,6 +63,13 @@ def represent_prop(item: T) -> T:
 
 def represent_prop(item: Union[str, T]) -> Union[str, T]:
     """represent items in a manner suitable for the audience (logging)"""
+    if not ismock(item) and hasmethod(item, "describe_to"):
+        return f"{item}"
     if isinstance(item, str):
         return repr(item)
-    return item
+
+    description = str(item)
+    if description[:1] == "<" and description[-1:] == ">":
+        return item
+
+    return f"<{item}>"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -639,7 +639,7 @@ class TestSeeAllOf:
                 (FakeQuestion(), IsEqualTo(True)),
             ).perform_as(Tester)
 
-    def test_stops_at_first_failure(self, Tester, caplog) -> None:
+    def test_log_first_failure(self, Tester, caplog) -> None:
         mock_question = FakeQuestion()
 
         caplog.set_level(logging.INFO)
@@ -669,7 +669,7 @@ class TestSeeAllOf:
             "     but: was <True>\n",
         ]
 
-    def test_passes_if_all_pass(self, Tester, caplog) -> None:
+    def test_log_all_pass(self, Tester, caplog) -> None:
         caplog.set_level(logging.INFO)
         # test passes if no exception is raised
         SeeAllOf(
@@ -760,14 +760,14 @@ class TestSeeAnyOf:
 
         assert "did not find any expected answers" in str(actual_exception)
 
-    def test_stops_at_first_pass(self, Tester, caplog) -> None:
+    def test_log_first_pass(self, Tester, caplog) -> None:
         mock_question = FakeQuestion()
 
         caplog.set_level(logging.INFO)
 
         SeeAnyOf(
             (mock_question, IsEqualTo(False)),
-            (mock_question, IsEqualTo(True)),  # <--
+            (mock_question, IsEqualTo(True)),
             (mock_question, IsEqualTo(True)),
             (mock_question, IsEqualTo(True)),
         ).perform_as(Tester)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -310,7 +310,7 @@ class TestEventually:
             Eventually(See(mock_question, IsEqualTo(False))).perform_as(Tester)
 
         assert str(actual_exception.value) == (
-            "Tester tried to Eventually see if returns bool is equal to False 3 times "
+            "Tester tried to Eventually see if returns bool is equal to <False> 3 times "
             "over 20.0 seconds, but got:\n"
             "    AssertionError: \n"
             "Expected: <False>\n"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -610,8 +610,10 @@ class TestSeeAllOf:
                 (FakeQuestion(), IsEqualTo(True)),
             ).perform_as(Tester)
 
-    def test_stops_at_first_failure(self, Tester) -> None:
+    def test_stops_at_first_failure(self, Tester, caplog) -> None:
         mock_question = FakeQuestion()
+
+        caplog.set_level(logging.INFO)
 
         with pytest.raises(AssertionError):
             SeeAllOf(
@@ -622,8 +624,24 @@ class TestSeeAllOf:
             ).perform_as(Tester)
 
         assert mock_question.answered_by.call_count == 2
+        assert [r.msg for r in caplog.records] == [
+            "Tester sees if all of 4 tests pass:",
+            "    Tester sees if fakeQuestion is equal to <True>.",
+            "        ... hoping it's equal to <True>.",
+            "            => <True>",
+            "    Tester sees if fakeQuestion is equal to <False>.",
+            "        ... hoping it's equal to <False>.",
+            "            => <False>",
+            # don't be fooled! the next few lines do not have commas on purpose
+            "        ***ERROR***\n"
+            "\n"
+            "AssertionError: \n"
+            "Expected: <False>\n"
+            "     but: was <True>\n",
+        ]
 
-    def test_passes_if_all_pass(self, Tester) -> None:
+    def test_passes_if_all_pass(self, Tester, caplog) -> None:
+        caplog.set_level(logging.INFO)
         # test passes if no exception is raised
         SeeAllOf(
             (FakeQuestion(), IsEqualTo(True)),
@@ -631,6 +649,22 @@ class TestSeeAllOf:
             (FakeQuestion(), IsEqualTo(True)),
             (FakeQuestion(), IsEqualTo(True)),
         ).perform_as(Tester)
+
+        assert [r.msg for r in caplog.records] == [
+            "Tester sees if all of 4 tests pass:",
+            "    Tester sees if fakeQuestion is equal to <True>.",
+            "        ... hoping it's equal to <True>.",
+            "            => <True>",
+            "    Tester sees if fakeQuestion is equal to <True>.",
+            "        ... hoping it's equal to <True>.",
+            "            => <True>",
+            "    Tester sees if fakeQuestion is equal to <True>.",
+            "        ... hoping it's equal to <True>.",
+            "            => <True>",
+            "    Tester sees if fakeQuestion is equal to <True>.",
+            "        ... hoping it's equal to <True>.",
+            "            => <True>",
+        ]
 
     def test_describe(self) -> None:
         test = (FakeQuestion(), IsEqualTo(True))
@@ -697,8 +731,10 @@ class TestSeeAnyOf:
 
         assert "did not find any expected answers" in str(actual_exception)
 
-    def test_stops_at_first_pass(self, Tester) -> None:
+    def test_stops_at_first_pass(self, Tester, caplog) -> None:
         mock_question = FakeQuestion()
+
+        caplog.set_level(logging.INFO)
 
         SeeAnyOf(
             (mock_question, IsEqualTo(False)),
@@ -708,6 +744,21 @@ class TestSeeAnyOf:
         ).perform_as(Tester)
 
         assert mock_question.answered_by.call_count == 2
+        assert [r.msg for r in caplog.records] == [
+            "Tester sees if any of 4 tests pass:",
+            "    Tester sees if fakeQuestion is equal to <False>.",
+            "        ... hoping it's equal to <False>.",
+            "            => <False>",
+            # don't be fooled! the next few lines do not have commas on purpose
+            "        ***ERROR***\n"
+            "\n"
+            "AssertionError: \n"
+            "Expected: <False>\n"
+            "     but: was <True>\n",
+            "    Tester sees if fakeQuestion is equal to <True>.",
+            "        ... hoping it's equal to <True>.",
+            "            => <True>",
+        ]
 
     def test_passes_with_one_pass(self, Tester) -> None:
         # test passes if no exception is raised

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -917,10 +917,10 @@ class TestSilentlyUnabridged:
 
         assert [r.msg for r in caplog.records] == [
             "Tester tries to Action2",
-            "    Tester sees if simpleQuestion is equal to True.",
+            "    Tester sees if simpleQuestion is equal to <True>.",
             "        Tester examines SimpleQuestion",
-            "            => True",
-            "        ... hoping it's equal to True.",
+            "            => <True>",
+            "        ... hoping it's equal to <True>.",
             "            => <True>",
         ]
 
@@ -956,10 +956,10 @@ class TestSilentlyUnabridged:
             "Tester tries to Action3",  # you'd think this wouldn't be here!
             "    Tester tries to Action1",
             "        Tester tries to Action2",
-            "            Tester sees if simpleQuestion is equal to True.",
+            "            Tester sees if simpleQuestion is equal to <True>.",
             "                Tester examines SimpleQuestion",
-            "                    => True",
-            "                ... hoping it's equal to True.",
+            "                    => <True>",
+            "                ... hoping it's equal to <True>.",
             "                    => <True>",
         ]
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -417,7 +417,7 @@ class TestMakeNote:
         assert "screenpy-docs.readthedocs.io" in str(exc.value)
 
     def test_describe(self) -> None:
-        assert MakeNote(None).as_("blah").describe() == "Make a note under blah."
+        assert MakeNote(None).as_("blah").describe() == "Make a note under 'blah'."
 
     @mock.patch("screenpy.actions.make_note.aside", autospec=True)
     def test_caught_exception_noted(self, mock_aside: mock.Mock, Tester) -> None:

--- a/tests/test_narration_integration.py
+++ b/tests/test_narration_integration.py
@@ -43,7 +43,7 @@ def _assert_stdout_correct(caplog) -> None:
     assert caplog.messages[1] == f"Scene: {TEST_SCENE.title()}"
     assert caplog.messages[2] == TEST_BEAT
     assert caplog.messages[3] == f"{INDENT}{TEST_ASIDE}"
-    assert caplog.messages[4] == f"{INDENT}=> {TEST_RETVAL}"
+    assert caplog.messages[4] == f"{INDENT}=> {TEST_RETVAL!r}"
 
 
 class TestNarrateToStdOut:

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -387,11 +387,19 @@ class TestIsEqualTo:
         assert not ie.matches(2)
 
     def test_description(self) -> None:
+        test_object = 8675
+
+        ie = IsEqualTo(test_object)
+
+        expected_description = "Equal to 8675."
+        assert ie.describe() == expected_description
+
+    def test_description_str(self) -> None:
         test_object = "my Schwartz"
 
         ie = IsEqualTo(test_object)
 
-        expected_description = f"Equal to {test_object}."
+        expected_description = "Equal to 'my Schwartz'."
         assert ie.describe() == expected_description
 
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -132,7 +132,7 @@ class TestContainsItemMatching:
         cim = ContainsItemMatching(test_pattern)
 
         expected_description = (
-            f'A sequence with an item matching the pattern r"{test_pattern}".'
+            'A sequence with an item matching the pattern r".*".'
         )
         assert cim.describe() == expected_description
 
@@ -172,8 +172,7 @@ class TestContainsTheEntry:
 
         expected_description_single = "A mapping with the entry 'spam'->'eggs'."
         expected_description_multiple = (
-            "A mapping with the entries"
-            f" {', '.join(f'{k!r}->{v!r}' for k, v in test_entries.items())}."
+            "A mapping with the entries 'number'->1234, 'spam'->'eggs'."
         )
         assert cte_single.describe() == expected_description_single
         assert cte_multiple.describe() == expected_description_multiple
@@ -197,7 +196,7 @@ class TestContainsTheItem:
 
         cti = ContainsTheItem(test_item)
 
-        expected_description = f'A sequence containing {test_item}.'
+        expected_description = "A sequence containing 1."
         assert cti.describe() == expected_description
 
     def test_description_str(self) -> None:
@@ -205,7 +204,7 @@ class TestContainsTheItem:
 
         cti = ContainsTheItem(test_item)
 
-        expected_description = f'A sequence containing {test_item!r}.'
+        expected_description = "A sequence containing '1'."
         assert cti.describe() == expected_description
 
 
@@ -228,7 +227,7 @@ class TestContainsTheKey:
 
         ctk = ContainsTheKey(test_key)
 
-        expected_description = f'Containing the key {test_key!r}.'
+        expected_description = "Containing the key 'spam'."
         assert ctk.describe() == expected_description
 
 
@@ -250,7 +249,7 @@ class TestContainsTheText:
 
         ctt = ContainsTheText(test_text)
 
-        expected_description = f'Containing the text {test_text!r}.'
+        expected_description = "Containing the text 'Wenn ist das Nunstück git und Slotermeyer?'."
         assert ctt.describe() == expected_description
 
 
@@ -273,7 +272,7 @@ class TestContainsTheValue:
 
         ctv = ContainsTheValue(test_value)
 
-        expected_description = f'Containing the value {test_value}.'
+        expected_description = "Containing the value 42."
         assert ctv.describe() == expected_description
 
     def test_description_str(self) -> None:
@@ -281,7 +280,7 @@ class TestContainsTheValue:
 
         ctv = ContainsTheValue(test_value)
 
-        expected_description = f'Containing the value {test_value!r}.'
+        expected_description = "Containing the value '42'."
         assert ctv.describe() == expected_description
 
 
@@ -321,7 +320,7 @@ class TestEndsWith:
 
         ew = EndsWith(test_postfix)
 
-        expected_description = f'Ending with {test_postfix!r}.'
+        expected_description = "Ending with 'got better.'."
         assert ew.describe() == expected_description
 
 
@@ -345,7 +344,7 @@ class TestHasLength:
         hl5 = HasLength(test_length)
 
         expected_description1 = "1 item long."
-        expected_description5 = f"{test_length} items long."
+        expected_description5 = "5 items long."
         assert hl1.describe() == expected_description1
         assert hl5.describe() == expected_description5
 
@@ -578,7 +577,7 @@ class TestMatches:
 
         m = Matches(test_match)
 
-        expected_description = f'Text matching the pattern r"{test_match}".'
+        expected_description = 'Text matching the pattern r"(spam)+".'
         assert m.describe() == expected_description
 
 
@@ -600,7 +599,7 @@ class TestReadsExactly:
 
         re_ = ReadsExactly(test_text)
 
-        expected_description = f'{test_text!r}, verbatim.'
+        expected_description = "'I will not buy this record, it is scratched.', verbatim."
         assert re_.describe() == expected_description
 
 
@@ -621,5 +620,5 @@ class TestStartsWith:
 
         sw = StartsWith(test_prefix)
 
-        expected_description = f'Starting with {test_prefix!r}.'
+        expected_description = "Starting with 'It was the best of times,'."
         assert sw.describe() == expected_description

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -123,7 +123,7 @@ class TestContainsItemMatching:
 
     def test_the_test(self) -> None:
         cim = ContainsItemMatching(r"([Ss]pam ?)+").resolve()
-        assert cim.matches(["Spam", "Eggs", "Spam and eggs"], )
+        assert cim.matches(["Spam", "Eggs", "Spam and eggs"])
         assert not cim.matches(["Porridge"])
 
     def test_description(self) -> None:

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -132,9 +132,7 @@ class TestContainsItemMatching:
 
         cim = ContainsItemMatching(test_pattern)
 
-        expected_description = (
-            'A sequence with an item matching the pattern r".*".'
-        )
+        expected_description = 'A sequence with an item matching the pattern r".*".'
         assert cim.describe() == expected_description
 
 
@@ -192,12 +190,13 @@ class TestContainsTheItem:
         assert cti.matches(range(0, 10))
         assert not cti.matches({0, 3, 5})
 
-    def test_description_uses_represent_prop(self) -> None:
-        cti_int = ContainsTheItem(1)
-        cti_str = ContainsTheItem("1")
-
-        assert cti_int.describe() == "A sequence containing <1>."
-        assert cti_str.describe() == "A sequence containing '1'."
+    @pytest.mark.parametrize(
+        ("arg", "expected"),
+        ((1, "A sequence containing <1>."), ("1", "A sequence containing '1'.")),
+    )
+    def test_description_uses_represent_prop(self, arg: object, expected: str) -> None:
+        cti = ContainsTheItem(arg)
+        assert cti.describe() == expected
 
 
 class TestContainsTheKey:
@@ -259,12 +258,14 @@ class TestContainsTheValue:
         assert ctv.matches({"key": "value", "play": "Hamlet"})
         assert not ctv.matches({"play": "Hamlet"})
 
-    def test_description_uses_represent_prop(self) -> None:
-        ctv_int = ContainsTheValue(42)
-        ctv_str = ContainsTheValue("42")
 
-        assert ctv_int.describe() == "Containing the value <42>."
-        assert ctv_str.describe() == "Containing the value '42'."
+    @pytest.mark.parametrize(
+        ("arg", "expected"),
+        ((42, "Containing the value <42>."), ("42", "Containing the value '42'.")),
+    )
+    def test_description_uses_represent_prop(self, arg: object, expected: str) -> None:
+        ctv = ContainsTheValue(arg)
+        assert ctv.describe() == expected
 
 
 class TestEmpty:
@@ -369,12 +370,13 @@ class TestIsEqualTo:
         assert ie.matches(1)
         assert not ie.matches(2)
 
-    def test_description_uses_represent_prop(self) -> None:
-        ie_int = IsEqualTo(8675)
-        ie_str = IsEqualTo("8675")
-
-        assert ie_int.describe() == "Equal to <8675>."
-        assert ie_str.describe() == "Equal to '8675'."
+    @pytest.mark.parametrize(
+        ("arg", "expected"),
+        ((8675, "Equal to <8675>."), ("8675", "Equal to '8675'.")),
+    )
+    def test_description_uses_represent_prop(self, arg: object, expected: str) -> None:
+        ie = IsEqualTo(arg)
+        assert ie.describe() == expected
 
 
 class TestIsGreaterThan:
@@ -581,7 +583,9 @@ class TestReadsExactly:
 
         re_ = ReadsExactly(test_text)
 
-        expected_description = "'I will not buy this record, it is scratched.', verbatim."
+        expected_description = (
+            "'I will not buy this record, it is scratched.', verbatim."
+        )
         assert re_.describe() == expected_description
 
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -150,10 +150,10 @@ class TestContainsTheEntry:
         cte_single = ContainsTheEntry(key="value").resolve()
         cte_multiple = ContainsTheEntry(key1="value1", key2="value2").resolve()
         cte_alt2 = ContainsTheEntry({"key2": 12345}).resolve()
-        cte_alt3 = ContainsTheEntry("key3", "something3").resolve()
+        cte_alt3 = ContainsTheEntry("key3", False).resolve()
 
         assert cte_alt2.matches({"key2": 12345})
-        assert cte_alt3.matches({"key3": "something3"})
+        assert cte_alt3.matches({"key3": False})
         assert cte_single.matches({"key": "value"})
         assert cte_single.matches({"key": "value", "play": "Hamlet"})
         assert not cte_single.matches({"play": "Hamlet"})
@@ -172,7 +172,7 @@ class TestContainsTheEntry:
 
         expected_description_single = "A mapping with the entry 'spam'->'eggs'."
         expected_description_multiple = (
-            "A mapping with the entries 'number'->1234, 'spam'->'eggs'."
+            "A mapping with the entries 'number'-><1234>, 'spam'->'eggs'."
         )
         assert cte_single.describe() == expected_description_single
         assert cte_multiple.describe() == expected_description_multiple
@@ -196,7 +196,7 @@ class TestContainsTheItem:
 
         cti = ContainsTheItem(test_item)
 
-        expected_description = "A sequence containing 1."
+        expected_description = "A sequence containing <1>."
         assert cti.describe() == expected_description
 
     def test_description_str(self) -> None:
@@ -272,7 +272,7 @@ class TestContainsTheValue:
 
         ctv = ContainsTheValue(test_value)
 
-        expected_description = "Containing the value 42."
+        expected_description = "Containing the value <42>."
         assert ctv.describe() == expected_description
 
     def test_description_str(self) -> None:
@@ -391,7 +391,7 @@ class TestIsEqualTo:
 
         ie = IsEqualTo(test_object)
 
-        expected_description = "Equal to 8675."
+        expected_description = "Equal to <8675>."
         assert ie.describe() == expected_description
 
     def test_description_str(self) -> None:

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -123,6 +123,7 @@ class TestContainsItemMatching:
 
     def test_the_test(self) -> None:
         cim = ContainsItemMatching(r"([Ss]pam ?)+").resolve()
+
         assert cim.matches(["Spam", "Eggs", "Spam and eggs"])
         assert not cim.matches(["Porridge"])
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -396,7 +396,7 @@ class TestIsGreaterThan:
 
         igt = IsGreaterThan(test_num)
 
-        expected_description = f"Greater than {test_num}."
+        expected_description = "Greater than <41>."
         assert igt.describe() == expected_description
 
 
@@ -419,7 +419,7 @@ class TestIsGreaterThanOrEqualTo:
 
         igtoet = IsGreaterThanOrEqualTo(test_num)
 
-        expected_description = f"Greater than or equal to {test_num}."
+        expected_description = "Greater than or equal to <1337>."
         assert igtoet.describe() == expected_description
 
 
@@ -493,7 +493,7 @@ class TestIsLessThan:
 
         ilt = IsLessThan(test_num)
 
-        expected_description = f"Less than {test_num}."
+        expected_description = "Less than <43>."
         assert ilt.describe() == expected_description
 
 
@@ -516,7 +516,7 @@ class TestIsLessThanOrEqualTo:
 
         iltoet = IsLessThanOrEqualTo(test_num)
 
-        expected_description = f"Less than or equal to {test_num}."
+        expected_description = "Less than or equal to <1337>."
         assert iltoet.describe() == expected_description
 
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -123,8 +123,7 @@ class TestContainsItemMatching:
 
     def test_the_test(self) -> None:
         cim = ContainsItemMatching(r"([Ss]pam ?)+").resolve()
-
-        assert cim.matches(["Spam", "Eggs", "Spam and eggs"])
+        assert cim.matches(["Spam", "Eggs", "Spam and eggs"], )
         assert not cim.matches(["Porridge"])
 
     def test_description(self) -> None:
@@ -150,10 +149,10 @@ class TestContainsTheEntry:
         """Matches dictionaries containing the entry(/ies)"""
         cte_single = ContainsTheEntry(key="value").resolve()
         cte_multiple = ContainsTheEntry(key1="value1", key2="value2").resolve()
-        cte_alt2 = ContainsTheEntry({"key2": "something2"}).resolve()
+        cte_alt2 = ContainsTheEntry({"key2": 12345}).resolve()
         cte_alt3 = ContainsTheEntry("key3", "something3").resolve()
 
-        assert cte_alt2.matches({"key2": "something2"})
+        assert cte_alt2.matches({"key2": 12345})
         assert cte_alt3.matches({"key3": "something3"})
         assert cte_single.matches({"key": "value"})
         assert cte_single.matches({"key": "value", "play": "Hamlet"})
@@ -166,15 +165,15 @@ class TestContainsTheEntry:
 
     def test_description(self) -> None:
         test_entry = {"spam": "eggs"}
-        test_entries = {"tree": "larch", "spam": "eggs"}
+        test_entries = {"tree": 1234, "spam": "eggs"}
 
         cte_single = ContainsTheEntry(**test_entry)
         cte_multiple = ContainsTheEntry(**test_entries)
 
-        expected_description_single = "A mapping with the entry spam->eggs."
+        expected_description_single = "A mapping with the entry 'spam'->'eggs'."
         expected_description_multiple = (
             "A mapping with the entries"
-            f" {', '.join(f'{k}->{v}' for k, v in test_entries.items())}."
+            f" {', '.join(f'{k!r}->{v!r}' for k, v in test_entries.items())}."
         )
         assert cte_single.describe() == expected_description_single
         assert cte_multiple.describe() == expected_description_multiple
@@ -198,7 +197,15 @@ class TestContainsTheItem:
 
         cti = ContainsTheItem(test_item)
 
-        expected_description = f'A sequence containing "{test_item}".'
+        expected_description = f'A sequence containing {test_item}.'
+        assert cti.describe() == expected_description
+
+    def test_description_str(self) -> None:
+        test_item = "1"
+
+        cti = ContainsTheItem(test_item)
+
+        expected_description = f'A sequence containing {test_item!r}.'
         assert cti.describe() == expected_description
 
 
@@ -221,7 +228,7 @@ class TestContainsTheKey:
 
         ctk = ContainsTheKey(test_key)
 
-        expected_description = f'Containing the key "{test_key}".'
+        expected_description = f'Containing the key {test_key!r}.'
         assert ctk.describe() == expected_description
 
 
@@ -243,7 +250,7 @@ class TestContainsTheText:
 
         ctt = ContainsTheText(test_text)
 
-        expected_description = f'Containing the text "{test_text}".'
+        expected_description = f'Containing the text {test_text!r}.'
         assert ctt.describe() == expected_description
 
 
@@ -266,7 +273,15 @@ class TestContainsTheValue:
 
         ctv = ContainsTheValue(test_value)
 
-        expected_description = f'Containing the value "{test_value}".'
+        expected_description = f'Containing the value {test_value}.'
+        assert ctv.describe() == expected_description
+
+    def test_description_str(self) -> None:
+        test_value = "42"
+
+        ctv = ContainsTheValue(test_value)
+
+        expected_description = f'Containing the value {test_value!r}.'
         assert ctv.describe() == expected_description
 
 
@@ -306,7 +321,7 @@ class TestEndsWith:
 
         ew = EndsWith(test_postfix)
 
-        expected_description = f'Ending with "{test_postfix}".'
+        expected_description = f'Ending with {test_postfix!r}.'
         assert ew.describe() == expected_description
 
 
@@ -585,7 +600,7 @@ class TestReadsExactly:
 
         re_ = ReadsExactly(test_text)
 
-        expected_description = f'"{test_text}", verbatim.'
+        expected_description = f'{test_text!r}, verbatim.'
         assert re_.describe() == expected_description
 
 
@@ -606,5 +621,5 @@ class TestStartsWith:
 
         sw = StartsWith(test_prefix)
 
-        expected_description = f'Starting with "{test_prefix}".'
+        expected_description = f'Starting with {test_prefix!r}.'
         assert sw.describe() == expected_description

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -192,21 +192,12 @@ class TestContainsTheItem:
         assert cti.matches(range(0, 10))
         assert not cti.matches({0, 3, 5})
 
-    def test_description(self) -> None:
-        test_item = 1
+    def test_description_uses_represent_prop(self) -> None:
+        cti_int = ContainsTheItem(1)
+        cti_str = ContainsTheItem("1")
 
-        cti = ContainsTheItem(test_item)
-
-        expected_description = "A sequence containing <1>."
-        assert cti.describe() == expected_description
-
-    def test_description_str(self) -> None:
-        test_item = "1"
-
-        cti = ContainsTheItem(test_item)
-
-        expected_description = "A sequence containing '1'."
-        assert cti.describe() == expected_description
+        assert cti_int.describe() == "A sequence containing <1>."
+        assert cti_str.describe() == "A sequence containing '1'."
 
 
 class TestContainsTheKey:
@@ -268,21 +259,12 @@ class TestContainsTheValue:
         assert ctv.matches({"key": "value", "play": "Hamlet"})
         assert not ctv.matches({"play": "Hamlet"})
 
-    def test_description(self) -> None:
-        test_value = 42
+    def test_description_uses_represent_prop(self) -> None:
+        ctv_int = ContainsTheValue(42)
+        ctv_str = ContainsTheValue("42")
 
-        ctv = ContainsTheValue(test_value)
-
-        expected_description = "Containing the value <42>."
-        assert ctv.describe() == expected_description
-
-    def test_description_str(self) -> None:
-        test_value = "42"
-
-        ctv = ContainsTheValue(test_value)
-
-        expected_description = "Containing the value '42'."
-        assert ctv.describe() == expected_description
+        assert ctv_int.describe() == "Containing the value <42>."
+        assert ctv_str.describe() == "Containing the value '42'."
 
 
 class TestEmpty:
@@ -387,21 +369,12 @@ class TestIsEqualTo:
         assert ie.matches(1)
         assert not ie.matches(2)
 
-    def test_description(self) -> None:
-        test_object = 8675
+    def test_description_uses_represent_prop(self) -> None:
+        ie_int = IsEqualTo(8675)
+        ie_str = IsEqualTo("8675")
 
-        ie = IsEqualTo(test_object)
-
-        expected_description = "Equal to <8675>."
-        assert ie.describe() == expected_description
-
-    def test_description_str(self) -> None:
-        test_object = "my Schwartz"
-
-        ie = IsEqualTo(test_object)
-
-        expected_description = "Equal to 'my Schwartz'."
-        assert ie.describe() == expected_description
+        assert ie_int.describe() == "Equal to <8675>."
+        assert ie_str.describe() == "Equal to '8675'."
 
 
 class TestIsGreaterThan:

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -165,7 +165,7 @@ class TestContainsTheEntry:
 
     def test_description(self) -> None:
         test_entry = {"spam": "eggs"}
-        test_entries = {"tree": 1234, "spam": "eggs"}
+        test_entries = {"number": 1234, "spam": "eggs"}
 
         cte_single = ContainsTheEntry(**test_entry)
         cte_multiple = ContainsTheEntry(**test_entries)

--- a/tests/test_speech_tools.py
+++ b/tests/test_speech_tools.py
@@ -1,6 +1,6 @@
 import pytest
 
-from screenpy.speech_tools import get_additive_description, tostring
+from screenpy.speech_tools import get_additive_description, represent_prop
 
 
 class ThisIsADescribableWithADescribe:
@@ -58,9 +58,9 @@ class TestTostring:
     def test_str(self):
         val = "hello\nworld!"
         
-        assert tostring(val) == "'hello\\nworld!'"
+        assert represent_prop(val) == "'hello\\nworld!'"
 
     def test_int(self):
         val = 1234
 
-        assert tostring(val) == val
+        assert represent_prop(val) == val

--- a/tests/test_speech_tools.py
+++ b/tests/test_speech_tools.py
@@ -1,6 +1,6 @@
 import pytest
 
-from screenpy.speech_tools import get_additive_description
+from screenpy.speech_tools import get_additive_description, tostring
 
 
 class ThisIsADescribableWithADescribe:
@@ -52,3 +52,15 @@ class TestGetAdditiveDescription:
         description = get_additive_description(Indescribable())
 
         assert description == "something indescribable"
+
+
+class TestTostring:
+    def test_str(self):
+        val = "hello\nworld!"
+        
+        assert tostring(val) == f"{val!r}"
+
+    def test_int(self):
+        val = 1234
+
+        assert tostring(val) == val

--- a/tests/test_speech_tools.py
+++ b/tests/test_speech_tools.py
@@ -58,7 +58,7 @@ class TestTostring:
     def test_str(self):
         val = "hello\nworld!"
         
-        assert tostring(val) == f"{val!r}"
+        assert tostring(val) == "'hello\\nworld!'"
 
     def test_int(self):
         val = 1234

--- a/tests/test_speech_tools.py
+++ b/tests/test_speech_tools.py
@@ -54,7 +54,7 @@ class TestGetAdditiveDescription:
         assert description == "something indescribable"
 
 
-class TestTostring:
+class TestRepresentProp:
     def test_str(self):
         val = "hello\nworld!"
         

--- a/tests/test_speech_tools.py
+++ b/tests/test_speech_tools.py
@@ -63,4 +63,4 @@ class TestRepresentProp:
     def test_int(self):
         val = 1234
 
-        assert represent_prop(val) == val
+        assert represent_prop(val) == "<1234>"

--- a/tests/useful_mocks.py
+++ b/tests/useful_mocks.py
@@ -8,7 +8,7 @@ def get_mock_action_class() -> Any:
     class FakeAction(Action):
         def __new__(cls, *args, **kwargs):
             rt = mock.create_autospec(FakeAction, instance=True)
-            rt.describe.return_value = None
+            rt.describe.return_value = "FakeAction"
             return rt
 
     return FakeAction
@@ -18,7 +18,7 @@ def get_mock_question_class() -> Any:
     class FakeQuestion(Question):
         def __new__(cls, *args, **kwargs):
             rt = mock.create_autospec(FakeQuestion, instance=True)
-            rt.describe.return_value = None
+            rt.describe.return_value = "FakeQuestion"
             rt.answered_by.return_value = True
             return rt
 
@@ -30,7 +30,7 @@ def get_mock_resolution_class() -> Any:
         def __new__(cls, *args, **kwargs):
             rt = mock.create_autospec(FakeResolution, instance=True)
             rt.resolve.return_value = rt
-            rt.describe.return_value = None
+            rt.describe.return_value = "FakeResolution"
             return rt
 
     return FakeResolution


### PR DESCRIPTION
This is a fix for the way different objects are represented when logging.

- strings will use `repr`.
- matcher objects that have a `describe_to` function will describe themselves.
- all other objects will surrounded the `__str__` output with angle brackets `<1>`, `<True>`, `<MyCustomObj>`