### PR TITLE
#99: Fix docs build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ files: '(screenpy|examples)/.*'
 fail_fast: false
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 23.9.1
   hooks:
   - id: black
     language_version: python3.11
@@ -12,12 +12,12 @@ repos:
   - id: isort
     language_version: python3.11
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
     language_version: python3.11
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.3.0
+  rev: v1.5.1
   hooks:
   - id: mypy
     language_version: python3.11

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/rtd-requirements.txt


### PR DESCRIPTION
The docs build started failing when we removed `typing_extensions` a while back, but we didn't notice!

The builds are failing because we didn't specify which Python version to use, so ReadTheDocs just uses a default of 3.7 (apparently). `Protocol` wasn't added to `typing` until after 3.7, so we get an import error.

This fixes that by adding [a `.readthedocs.yaml` config file](https://docs.readthedocs.io/en/stable/config-file/v2.html), which can specify which version of Python to use!