### PR TITLE
#126: fix MakeNote.key_to_log not being updated.

### DIFF
--- a/screenpy/actions/make_note.py
+++ b/screenpy/actions/make_note.py
@@ -37,6 +37,7 @@ class MakeNote:
     """
 
     key: str | None
+    key_to_log: str | None
     question: T_Q
 
     @classmethod
@@ -56,6 +57,7 @@ class MakeNote:
     def as_(self, key: str) -> Self:
         """Set the key to use to recall this noted value."""
         self.key = key
+        self.key_to_log = represent_prop(key)
         return self
 
     def describe(self) -> str:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -384,6 +384,7 @@ class TestMakeNote:
 
         assert mn.question == test_question
         assert mn.key == test_key
+        assert mn.key_to_log == f"'{test_key}'"
 
     def test_answers_question(self, Tester: Actor) -> None:
         mock_question = FakeQuestion()


### PR DESCRIPTION
In `MakeNote.as_`, we forget to update `key_to_log`. This caused the logs to read things like:

```
Guido jots something down under <None>.
Guido jots something down under <None>.
Guido jots something down under <None>.
```

Now!
```
Guido jots something down under "my birthday".
Guido jots something down under "gift ideas".
Guido jots something down under "friends to invite".
```