### PR TITLE
Remove unnecessary paths from Sphinx directives.

### DIFF
--- a/docs/api/actions.rst
+++ b/docs/api/actions.rst
@@ -24,11 +24,30 @@ Debug
 .. autoclass:: Debug
     :members:
 
+Either
+------
+
+**Aliases**: ``Attempt``,
+``AttemptTo``,
+``GoFor``,
+``Try``
+``TryTo``,
+``Attempts``,
+``AttemptsTo``,
+``GoesFor``,
+``Tries``,
+``TriesTo``
+
+.. autoclass:: Either
+    :members:
+    :exclude-members: except_, else_, otherwise, alternatively, failing_that
+
 Eventually
 ----------
 
 .. autoclass:: Eventually
     :members:
+    :exclude-members: trying_for_no_longer_than, trying_for, waiting_for, polling_every, trying_every
 
 Log
 ---
@@ -45,6 +64,7 @@ MakeNote
 
 .. autoclass:: MakeNote
     :members:
+    :exclude-members: of_the
 
 Pause
 -----
@@ -55,6 +75,7 @@ Pause
 
 .. autoclass:: Pause
     :members:
+    :exclude-members: second_because,
 
 See
 ---
@@ -112,21 +133,3 @@ Silently
 **Aliases**: ``Quietly``
 
 .. autofunction:: Silently
-
-
-Either
-------
-
-**Aliases**: ``Attempt``,
-``AttemptTo``,
-``GoFor``,
-``Try``
-``TryTo``,
-``Attempts``,
-``AttemptsTo``,
-``GoesFor``,
-``Tries``,
-``TriesTo``
-
-.. autoclass:: Either
-    :members:

--- a/docs/api/actors.rst
+++ b/docs/api/actors.rst
@@ -4,3 +4,10 @@ Actor API
 
 .. autoclass:: screenpy.actor.Actor
     :members:
+    :exclude-members:
+        can,
+        with_ordered_cleanup_tasks, with_independent_cleanup_tasks,
+        ability_to,
+        was_able_to, did, will, tries_to, tried_to, tries, tried, does, should, shall
+        perform,
+        exit_stage_left, exit_stage_right, exit_through_vomitorium

--- a/screenpy/actions/either.py
+++ b/screenpy/actions/either.py
@@ -25,7 +25,7 @@ class Either:
 
     By default, ``Either`` catches AssertionErrors, so you can use
     :class:`~screenpy.actions.See` to decide which path to follow. Use the
-    :meth:`~screenpy.actions.Either.ignoring` method to ignore other exceptions.
+    :meth:`ignoring` method to ignore other exceptions.
 
     Examples::
 
@@ -46,33 +46,15 @@ class Either:
     except_performables: tuple[Performable, ...]
     ignore_exceptions: tuple[type[BaseException], ...]
 
-    def perform_as(self, the_actor: Actor) -> None:
-        """Direct the Actor to perform one of two performances."""
-        # kinking the cable before the attempt
-        # avoids explaning what the actor tries to do.
-        # logs the first attempt only if it succeeds
-        # or if UNABRIDGED_NARRATION is enabled
-        with the_narrator.mic_cable_kinked():
-            try:
-                the_actor.will(*self.try_performables)
-            except self.ignore_exceptions:
-                if not settings.UNABRIDGED_NARRATION:
-                    the_narrator.clear_backup()
-            else:
-                return
-
-        the_actor.will(*self.except_performables)
-        return
-
     def or_(self, *except_performables: Performable) -> Self:
         """Provide the alternative routine to perform.
 
         Aliases:
-            * :meth:`~screenpy.actions.Either.except_`
-            * :meth:`~screenpy.actions.Either.else_`
-            * :meth:`~screenpy.actions.Either.otherwise`
-            * :meth:`~screenpy.actions.Either.alternatively`
-            * :meth:`~screenpy.actions.Either.failing_that`
+            * :meth:`except_`
+            * :meth:`else_`
+            * :meth:`otherwise`
+            * :meth:`alternatively`
+            * :meth:`failing_that`
         """
         self.except_performables = except_performables
         return self
@@ -94,6 +76,24 @@ class Either:
         )
 
         return f"Either {try_summary} or {except_summary}"
+
+    def perform_as(self, the_actor: Actor) -> None:
+        """Direct the Actor to perform one of two performances."""
+        # kinking the cable before the attempt
+        # avoids explaning what the actor tries to do.
+        # logs the first attempt only if it succeeds
+        # or if UNABRIDGED_NARRATION is enabled
+        with the_narrator.mic_cable_kinked():
+            try:
+                the_actor.will(*self.try_performables)
+            except self.ignore_exceptions:
+                if not settings.UNABRIDGED_NARRATION:
+                    the_narrator.clear_backup()
+            else:
+                return
+
+        the_actor.will(*self.except_performables)
+        return
 
     def __init__(self, *first: Performable) -> None:
         self.try_performables: tuple[Performable, ...] = first

--- a/screenpy/actions/either.py
+++ b/screenpy/actions/either.py
@@ -50,11 +50,11 @@ class Either:
         """Provide the alternative routine to perform.
 
         Aliases:
-            * :meth:`except_`
-            * :meth:`else_`
-            * :meth:`otherwise`
-            * :meth:`alternatively`
-            * :meth:`failing_that`
+            * ``except_``
+            * ``else_``
+            * ``otherwise``
+            * ``alternatively``
+            * ``failing_that``
         """
         self.except_performables = except_performables
         return self

--- a/screenpy/actions/eventually.py
+++ b/screenpy/actions/eventually.py
@@ -81,40 +81,40 @@ class Eventually:
         """Set for how long the actor should continue trying.
 
         Aliases:
-            * :meth:`~screenpy.actions.Eventually.trying_for_no_longer_than`
-            * :meth:`~screenpy.actions.Eventually.trying_for`
-            * :meth:`~screenpy.actions.Eventually.waiting_for`
+            * :meth:`trying_for_no_longer_than`
+            * :meth:`trying_for`
+            * :meth:`waiting_for`
         """
         return self._TimeframeBuilder(self, amount, "timeout")
 
     def trying_for_no_longer_than(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`~screenpy.actions.Eventually.for_`."""
+        """Alias for :meth:`for_`."""
         return self.for_(amount)
 
     def trying_for(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`~screenpy.actions.Eventually.for_`."""
+        """Alias for :meth:`for_`."""
         return self.for_(amount)
 
     def waiting_for(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`~screenpy.actions.Eventually.for_`."""
+        """Alias for :meth:`for_`."""
         return self.for_(amount)
 
     def polling(self, amount: float) -> _TimeframeBuilder:
         """Adjust the polling frequency.
 
         Aliases:
-            * :meth:`~screenpy.actions.Eventually.polling_every`
-            * :meth:`~screenpy.actions.Eventually.trying_every`
+            * :meth:`polling_every`
+            * :meth:`trying_every`
         """
         self.poll = amount
         return self._TimeframeBuilder(self, amount, "poll")
 
     def polling_every(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`~screenpy.actions.Eventually.polling`."""
+        """Alias for :meth:`polling`."""
         return self.polling(amount)
 
     def trying_every(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`~screenpy.actions.Eventually.polling`."""
+        """Alias for :meth:`polling`."""
         return self.polling(amount)
 
     def describe(self) -> str:

--- a/screenpy/actions/eventually.py
+++ b/screenpy/actions/eventually.py
@@ -81,41 +81,25 @@ class Eventually:
         """Set for how long the actor should continue trying.
 
         Aliases:
-            * :meth:`trying_for_no_longer_than`
-            * :meth:`trying_for`
-            * :meth:`waiting_for`
+            * ``trying_for_no_longer_than``
+            * ``trying_for``
+            * ``waiting_for``
         """
         return self._TimeframeBuilder(self, amount, "timeout")
 
-    def trying_for_no_longer_than(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`for_`."""
-        return self.for_(amount)
-
-    def trying_for(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`for_`."""
-        return self.for_(amount)
-
-    def waiting_for(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`for_`."""
-        return self.for_(amount)
+    trying_for_no_longer_than = trying_for = waiting_for = for_
 
     def polling(self, amount: float) -> _TimeframeBuilder:
         """Adjust the polling frequency.
 
         Aliases:
-            * :meth:`polling_every`
-            * :meth:`trying_every`
+            * ``polling_every``
+            * ``trying_every``
         """
         self.poll = amount
         return self._TimeframeBuilder(self, amount, "poll")
 
-    def polling_every(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`polling`."""
-        return self.polling(amount)
-
-    def trying_every(self, amount: float) -> _TimeframeBuilder:
-        """Alias for :meth:`polling`."""
-        return self.polling(amount)
+    polling_every = trying_every = polling
 
     def describe(self) -> str:
         """Describe the Action in present tense."""

--- a/screenpy/actions/make_note.py
+++ b/screenpy/actions/make_note.py
@@ -45,14 +45,11 @@ class MakeNote:
         """Supply the Question to answer and its arguments.
 
         Aliases:
-            * :meth:`of_the`
+            * ``of_the``
         """
         return cls(question)
 
-    @classmethod
-    def of_the(cls, question: T_Q) -> Self:
-        """Alias for :meth:`of`."""
-        return cls.of(question)
+    of_the = of
 
     def as_(self, key: str) -> Self:
         """Set the key to use to recall this noted value."""

--- a/screenpy/actions/make_note.py
+++ b/screenpy/actions/make_note.py
@@ -45,13 +45,13 @@ class MakeNote:
         """Supply the Question to answer and its arguments.
 
         Aliases:
-            * :meth:`~screenpy.actions.MakeNote.of_the`
+            * :meth:`of_the`
         """
         return cls(question)
 
     @classmethod
     def of_the(cls, question: T_Q) -> Self:
-        """Alias for :meth:`~screenpy.actions.MakeNote.of`."""
+        """Alias for :meth:`of`."""
         return cls.of(question)
 
     def as_(self, key: str) -> Self:

--- a/screenpy/actions/make_note.py
+++ b/screenpy/actions/make_note.py
@@ -49,7 +49,13 @@ class MakeNote:
         """
         return cls(question)
 
-    of_the = of
+    @classmethod
+    def of_the(cls, question: T_Q) -> Self:
+        """Alias for :meth:`of`.
+
+        Workaround for https://github.com/python/mypy/issues/6700
+        """
+        return cls.of(question)
 
     def as_(self, key: str) -> Self:
         """Set the key to use to recall this noted value."""

--- a/screenpy/actions/pause.py
+++ b/screenpy/actions/pause.py
@@ -50,14 +50,14 @@ class Pause:
         """Use seconds and provide a reason for the pause.
 
         Aliases:
-            * :meth:`~screenpy.actions.Pause.second_because`
+            * :meth:`second_because`
         """
         self.unit = f"second{'s' if self.number != 1 else ''}"
         self.reason = self._massage_reason(reason)
         return self
 
     def second_because(self, reason: str) -> Self:
-        """Alias for :meth:`~screenpy.actions.Pause.seconds_because`."""
+        """Alias for :meth:`seconds_because`."""
         return self.seconds_because(reason)
 
     def milliseconds_because(self, reason: str) -> Self:

--- a/screenpy/actions/pause.py
+++ b/screenpy/actions/pause.py
@@ -50,15 +50,13 @@ class Pause:
         """Use seconds and provide a reason for the pause.
 
         Aliases:
-            * :meth:`second_because`
+            * ``second_because``
         """
         self.unit = f"second{'s' if self.number != 1 else ''}"
         self.reason = self._massage_reason(reason)
         return self
 
-    def second_because(self, reason: str) -> Self:
-        """Alias for :meth:`seconds_because`."""
-        return self.seconds_because(reason)
+    second_because = seconds_because
 
     def milliseconds_because(self, reason: str) -> Self:
         """Use milliseconds and provide a reason for the pause."""

--- a/screenpy/actor.py
+++ b/screenpy/actor.py
@@ -68,13 +68,13 @@ class Actor:
         """Add one or more Abilities to this Actor.
 
         Aliases:
-            * :meth:`~screenpy.actor.Actor.can`
+            * :meth:`can`
         """
         self.abilities.extend(abilities)
         return self
 
     def can(self, *abilities: T_Ability) -> Self:
-        """Alias for :meth:`~screenpy.actor.Actor.who_can`."""
+        """Alias for :meth:`who_can`."""
         return self.who_can(*abilities)
 
     def has_ordered_cleanup_tasks(self, *tasks: Performable) -> Self:
@@ -85,13 +85,13 @@ class Actor:
         and will be discarded.
 
         Aliases:
-            * :meth:`~screenpy.actor.Actor.with_ordered_cleanup_tasks`
+            * :meth:`with_ordered_cleanup_tasks`
         """
         self.ordered_cleanup_tasks.extend(tasks)
         return self
 
     def with_ordered_cleanup_tasks(self, *tasks: Performable) -> Self:
-        """Alias for :meth:`~screenpy.actor.Actor.has_ordered_cleanup_tasks`."""
+        """Alias for :meth:`has_ordered_cleanup_tasks`."""
         return self.has_ordered_cleanup_tasks(*tasks)
 
     def has_independent_cleanup_tasks(self, *tasks: Performable) -> Self:
@@ -102,13 +102,13 @@ class Actor:
         previous ones were successful.
 
         Aliases:
-            * :meth:`~screenpy.actor.Actor.with_independent_cleanup_tasks`
+            * :meth:`with_independent_cleanup_tasks`
         """
         self.independent_cleanup_tasks.extend(tasks)
         return self
 
     def with_independent_cleanup_tasks(self, *tasks: Performable) -> Self:
-        """Alias for :meth:`~screenpy.actor.Actor.has_independent_cleanup_tasks`."""
+        """Alias for :meth:`has_independent_cleanup_tasks`."""
         return self.has_independent_cleanup_tasks(*tasks)
 
     def uses_ability_to(self, ability: type[T_Ability]) -> T_Ability:
@@ -118,7 +118,7 @@ class Actor:
             UnableToPerform: the Actor doesn't possess the Ability.
 
         Aliases:
-            * :meth:`~screenpy.actor.Actor.ability_to`
+            * :meth:`ability_to`
         """
         for a in self.abilities:
             if isinstance(a, ability):
@@ -128,7 +128,7 @@ class Actor:
         raise UnableToPerform(msg)
 
     def ability_to(self, ability: type[T_Ability]) -> T_Ability:
-        """Alias for :meth:`~screenpy.actor.Actor.uses_ability_to`."""
+        """Alias for :meth:`uses_ability_to`."""
         return self.uses_ability_to(ability)
 
     def has_ability_to(self, ability: type[T_Ability]) -> bool:
@@ -144,58 +144,58 @@ class Actor:
         """Perform a list of Actions, one after the other.
 
         Aliases:
-            * :meth:`~screenpy.actor.Actor.was_able_to`
-            * :meth:`~screenpy.actor.Actor.should`
-            * :meth:`~screenpy.actor.Actor.shall`
-            * :meth:`~screenpy.actor.Actor.will`
-            * :meth:`~screenpy.actor.Actor.tries_to`
-            * :meth:`~screenpy.actor.Actor.tried_to`
-            * :meth:`~screenpy.actor.Actor.tries`
-            * :meth:`~screenpy.actor.Actor.tried`
-            * :meth:`~screenpy.actor.Actor.does`
-            * :meth:`~screenpy.actor.Actor.did`
+            * :meth:`was_able_to`
+            * :meth:`did`
+            * :meth:`will`
+            * :meth:`tries_to`
+            * :meth:`tried_to`
+            * :meth:`tries`
+            * :meth:`tried`
+            * :meth:`does`
+            * :meth:`should`
+            * :meth:`shall`
         """
         for action in actions:
             self.perform(action)
 
     def was_able_to(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def tries_to(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def tried_to(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def tries(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def tried(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def does(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def did(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def will(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def shall(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def should(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def perform(self, action: Performable) -> None:
@@ -234,9 +234,9 @@ class Actor:
         """Direct the Actor to forget all their Abilities.
 
         Aliases:
-            * :meth:`~screenpy.actor.Actor.exit_stage_left`
-            * :meth:`~screenpy.actor.Actor.exit_stage_right`
-            * :meth:`~screenpy.actor.Actor.exit_through_vomitorium`
+            * :meth:`exit_stage_left`
+            * :meth:`exit_stage_right`
+            * :meth:`exit_through_vomitorium`
         """
         self.cleans_up()
         for ability in self.abilities:
@@ -244,19 +244,19 @@ class Actor:
         self.abilities = []
 
     def exit_stage_left(self) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.exit`."""
+        """Alias for :meth:`exit`."""
         return self.exit()
 
     def exit_stage_right(self) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.exit`."""
+        """Alias for :meth:`exit`."""
         return self.exit()
 
     def exit_through_vomitorium(self) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.exit`."""
+        """Alias for :meth:`exit`."""
         return self.exit()
 
     def __call__(self, *actions: Performable) -> None:
-        """Alias for :meth:`~screenpy.actor.Actor.attempts_to`."""
+        """Alias for :meth:`attempts_to`."""
         return self.attempts_to(*actions)
 
     def __repr__(self) -> str:

--- a/screenpy/actor.py
+++ b/screenpy/actor.py
@@ -68,14 +68,12 @@ class Actor:
         """Add one or more Abilities to this Actor.
 
         Aliases:
-            * :meth:`can`
+            * ``can``
         """
         self.abilities.extend(abilities)
         return self
 
-    def can(self, *abilities: T_Ability) -> Self:
-        """Alias for :meth:`who_can`."""
-        return self.who_can(*abilities)
+    can = who_can
 
     def has_ordered_cleanup_tasks(self, *tasks: Performable) -> Self:
         """Assign one or more tasks for the Actor to perform when exiting.
@@ -85,14 +83,12 @@ class Actor:
         and will be discarded.
 
         Aliases:
-            * :meth:`with_ordered_cleanup_tasks`
+            * ``with_ordered_cleanup_tasks``
         """
         self.ordered_cleanup_tasks.extend(tasks)
         return self
 
-    def with_ordered_cleanup_tasks(self, *tasks: Performable) -> Self:
-        """Alias for :meth:`has_ordered_cleanup_tasks`."""
-        return self.has_ordered_cleanup_tasks(*tasks)
+    with_ordered_cleanup_tasks = has_ordered_cleanup_tasks
 
     def has_independent_cleanup_tasks(self, *tasks: Performable) -> Self:
         """Assign one or more tasks for the Actor to perform when exiting.
@@ -102,14 +98,12 @@ class Actor:
         previous ones were successful.
 
         Aliases:
-            * :meth:`with_independent_cleanup_tasks`
+            * ``with_independent_cleanup_tasks``
         """
         self.independent_cleanup_tasks.extend(tasks)
         return self
 
-    def with_independent_cleanup_tasks(self, *tasks: Performable) -> Self:
-        """Alias for :meth:`has_independent_cleanup_tasks`."""
-        return self.has_independent_cleanup_tasks(*tasks)
+    with_independent_cleanup_tasks = has_independent_cleanup_tasks
 
     def uses_ability_to(self, ability: type[T_Ability]) -> T_Ability:
         """Find the Ability referenced and return it, if the Actor is capable.
@@ -118,7 +112,7 @@ class Actor:
             UnableToPerform: the Actor doesn't possess the Ability.
 
         Aliases:
-            * :meth:`ability_to`
+            * ``ability_to``
         """
         for a in self.abilities:
             if isinstance(a, ability):
@@ -127,9 +121,7 @@ class Actor:
         msg = f"{self} does not have the Ability to {ability}"
         raise UnableToPerform(msg)
 
-    def ability_to(self, ability: type[T_Ability]) -> T_Ability:
-        """Alias for :meth:`uses_ability_to`."""
-        return self.uses_ability_to(ability)
+    ability_to = uses_ability_to
 
     def has_ability_to(self, ability: type[T_Ability]) -> bool:
         """Ask whether the Actor has the Ability to do something."""
@@ -144,59 +136,23 @@ class Actor:
         """Perform a list of Actions, one after the other.
 
         Aliases:
-            * :meth:`was_able_to`
-            * :meth:`did`
-            * :meth:`will`
-            * :meth:`tries_to`
-            * :meth:`tried_to`
-            * :meth:`tries`
-            * :meth:`tried`
-            * :meth:`does`
-            * :meth:`should`
-            * :meth:`shall`
+            * ``was_able_to``
+            * ``did``
+            * ``will``
+            * ``tries_to``
+            * ``tried_to``
+            * ``tries``
+            * ``tried``
+            * ``does``
+            * ``should``
+            * ``shall``
         """
         for action in actions:
             self.perform(action)
 
-    def was_able_to(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def tries_to(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def tried_to(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def tries(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def tried(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def does(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def did(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def will(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def shall(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
-
-    def should(self, *actions: Performable) -> None:
-        """Alias for :meth:`attempts_to`."""
-        return self.attempts_to(*actions)
+    was_able_to = did = attempts_to
+    tries_to = tried_to = tries = tried = does = will = attempts_to
+    shall = should = attempts_to
 
     def perform(self, action: Performable) -> None:
         """Perform an Action."""
@@ -231,29 +187,19 @@ class Actor:
         self.cleans_up_ordered_tasks()
 
     def exit(self) -> None:
-        """Direct the Actor to forget all their Abilities.
+        """Direct the Actor to clean up and forget all their Abilities.
 
         Aliases:
-            * :meth:`exit_stage_left`
-            * :meth:`exit_stage_right`
-            * :meth:`exit_through_vomitorium`
+            * ``exit_stage_left``
+            * ``exit_stage_right``
+            * ``exit_through_vomitorium``
         """
         self.cleans_up()
         for ability in self.abilities:
             ability.forget()
         self.abilities = []
 
-    def exit_stage_left(self) -> None:
-        """Alias for :meth:`exit`."""
-        return self.exit()
-
-    def exit_stage_right(self) -> None:
-        """Alias for :meth:`exit`."""
-        return self.exit()
-
-    def exit_through_vomitorium(self) -> None:
-        """Alias for :meth:`exit`."""
-        return self.exit()
+    exit_stage_left = exit_stage_right = exit_through_vomitorium = exit
 
     def __call__(self, *actions: Performable) -> None:
         """Alias for :meth:`attempts_to`."""

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -362,9 +362,9 @@ class TestLog:
 
 class TestMakeNote:
     def test_can_be_instantiated(self) -> None:
-        mn1 = MakeNote(None)
-        mn2 = MakeNote.of(None)
-        mn3 = MakeNote.of_the(None).as_("")
+        mn1 = MakeNote(FakeQuestion())
+        mn2 = MakeNote.of(FakeQuestion())
+        mn3 = MakeNote.of_the(FakeQuestion()).as_("")
 
         assert isinstance(mn1, MakeNote)
         assert isinstance(mn2, MakeNote)
@@ -393,7 +393,7 @@ class TestMakeNote:
 
     def test_raises_without_key(self, Tester: Actor) -> None:
         with pytest.raises(UnableToAct):
-            MakeNote.of_the(None).perform_as(Tester)
+            MakeNote.of_the(FakeQuestion()).perform_as(Tester)
 
     def test_adds_note_to_director(self, Tester: Actor) -> None:
         key = "key"


### PR DESCRIPTION
I just found out yesterday that when you're in the class, you don't need to supply the path to the method! You can just do 
```rst
:meth:`methodname`
```

Life-changing. But more life-changing is our decision to document aliases differently, mentioning them in the base class and skipping their documentation in the ... documentation. This PR does both of those things!