### PR TITLE
allowing `Matches` to accept `re.compile`

### DIFF
--- a/screenpy/resolutions/matches.py
+++ b/screenpy/resolutions/matches.py
@@ -1,9 +1,16 @@
 """Matches a string using a regex pattern."""
 
+from __future__ import annotations
+
+from re import Pattern
+from typing import TYPE_CHECKING
+
 from hamcrest import matches_regexp
-from hamcrest.core.matcher import Matcher
 
 from screenpy.pacing import beat
+
+if TYPE_CHECKING:  # pragma: no cover
+    from hamcrest.core.matcher import Matcher
 
 
 class Matches:
@@ -17,14 +24,21 @@ class Matches:
         )
     """
 
+    @property
+    def item_to_log(self) -> str:
+        """Represent the item in a log-friendly way."""
+        if isinstance(self.pattern, Pattern):
+            return f"r'{self.pattern.pattern}'"
+        return f"r'{self.pattern}'"
+
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f'Text matching the pattern r"{self.pattern}".'
+        return f"Text matching the pattern {self.item_to_log}."
 
-    @beat('... hoping it\'s text matching the pattern r"{pattern}".')
+    @beat("... hoping it's text matching the pattern {item_to_log}.")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return matches_regexp(self.pattern)
 
-    def __init__(self, pattern: str) -> None:
+    def __init__(self, pattern: str | Pattern[str]) -> None:
         self.pattern = pattern

--- a/screenpy/resolutions/matches.py
+++ b/screenpy/resolutions/matches.py
@@ -22,6 +22,11 @@ class Matches:
             # matches "/product/1", "/product/22", "/product/942"...
             See.the(Text.of_the(URL), Matches(r"/product/[0-9]{1,3}"))
         )
+
+        # matches "/people/123/edit", "/people/2ec4efef-dec5-9d81bbcc410a/edit"
+        pattern = re.compile(r"/people/.+/edit")
+        the_actor.should(See.the(Text.of_the(URL), Matches(pattern))
+
     """
 
     @property

--- a/screenpy/resolutions/matches.py
+++ b/screenpy/resolutions/matches.py
@@ -25,7 +25,7 @@ class Matches:
     """
 
     @property
-    def item_to_log(self) -> str:
+    def pattern_to_log(self) -> str:
         """Represent the item in a log-friendly way."""
         if isinstance(self.pattern, Pattern):
             return f"r'{self.pattern.pattern}'"
@@ -33,9 +33,9 @@ class Matches:
 
     def describe(self) -> str:
         """Describe the Resolution's expectation."""
-        return f"Text matching the pattern {self.item_to_log}."
+        return f"Text matching the pattern {self.pattern_to_log}."
 
-    @beat("... hoping it's text matching the pattern {item_to_log}.")
+    @beat("... hoping it's text matching the pattern {pattern_to_log}.")
     def resolve(self) -> Matcher[str]:
         """Produce the Matcher to make the assertion."""
         return matches_regexp(self.pattern)

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import re
 from itertools import chain
 from unittest import mock
 
@@ -570,12 +572,35 @@ class TestMatches:
         assert m.matches("Spam spam spam spam baked beans and spam")
         assert not m.matches("What do you mean Eugh?!")
 
+    def test_the_test_with_compile(self) -> None:
+        m = Matches(re.compile(r"([Ss]pam ?)+")).resolve()
+
+        assert m.matches("Spam spam spam spam baked beans and spam")
+        assert not m.matches("What do you mean Eugh?!")
+
     def test_description(self) -> None:
         test_match = r"(spam)+"
 
         m = Matches(test_match)
 
-        expected_description = 'Text matching the pattern r"(spam)+".'
+        expected_description = "Text matching the pattern r'(spam)+'."
+        assert m.describe() == expected_description
+
+    def test_beat_logging(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO)
+        Matches(r"pattern").resolve()
+
+        assert [r.msg for r in caplog.records] == [
+            "... hoping it's text matching the pattern r'pattern'.",
+            "    => a string matching 'pattern'",
+        ]
+
+    def test_description_with_compile(self) -> None:
+        test_match = re.compile(r"(spam)+")
+
+        m = Matches(test_match)
+
+        expected_description = "Text matching the pattern r'(spam)+'."
         assert m.describe() == expected_description
 
 

--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -588,11 +588,11 @@ class TestMatches:
 
     def test_beat_logging(self, caplog: pytest.LogCaptureFixture) -> None:
         caplog.set_level(logging.INFO)
-        Matches(r"pattern").resolve()
+        Matches(r"\tpattern").resolve()
 
         assert [r.msg for r in caplog.records] == [
-            "... hoping it's text matching the pattern r'pattern'.",
-            "    => a string matching 'pattern'",
+            r"... hoping it's text matching the pattern r'\tpattern'.",
+            r"    => a string matching '\tpattern'",
         ]
 
     def test_description_with_compile(self) -> None:


### PR DESCRIPTION
The resolving function `matches_regexp` of `Matches` can accept either `str` or `Pattern`.  This update makes it possible to pass the pattern directly into `Matches`.